### PR TITLE
Fix failing process transfer because of duplicate key exception caused by duplicate transfer

### DIFF
--- a/src/Command/ProcessTransferCommand.php
+++ b/src/Command/ProcessTransferCommand.php
@@ -114,8 +114,10 @@ class ProcessTransferCommand extends Command implements LoggerAwareInterface
 
                 // add failed mirakl orders older than $lastMiraklUpdateTime
                 $failedOrderIds = $this->stripeTransferRepository->getMiraklOrderIdFailTransfersBefore($lastMiraklUpdateTime);
-                $miraklFailedTransferOrders = $this->miraklClient->listOrdersById($failedOrderIds);
-                $miraklOrders = array_merge($miraklOrders, $miraklFailedTransferOrders);
+                if (! empty($failedOrderIds)) {
+                    $miraklFailedTransferOrders = $this->miraklClient->listOrdersById($failedOrderIds);
+                    $miraklOrders = array_merge($miraklOrders, $miraklFailedTransferOrders);
+                }
             } else {
                 $this->logger->info('Executing for all orders');
                 $miraklOrders = $this->miraklClient->listOrders();

--- a/tests/Command/ProcessTransferCommandIntegrationTest.php
+++ b/tests/Command/ProcessTransferCommandIntegrationTest.php
@@ -274,4 +274,22 @@ class ProcessTransferCommandIntegrationTest extends KernelTestCase
         $this->assertEquals(0, $commandTester->getStatusCode());
         $this->assertCount(0, $this->doctrineReceiver->getSent());
     }
+
+    public function testTransferWithNoFailedTransfer()
+    {
+        $commandTester = new CommandTester($this->command);
+
+        $commandTester->execute([
+            'command' => $this->command->getName()
+        ]);
+
+        $stripeTransfersPending = $this->stripeTransferRepository->findBy([
+            'status' => StripeTransfer::TRANSFER_PENDING,
+            'miraklId' => 'order_4'
+        ]);
+
+        $this->assertEquals(0, $commandTester->getStatusCode());
+        $this->assertCount(1, $this->doctrineReceiver->getSent());
+        $this->assertCount(1, $stripeTransfersPending);
+    }
 }

--- a/tests/MiraklMockedHttpClient.php
+++ b/tests/MiraklMockedHttpClient.php
@@ -47,6 +47,8 @@ class MiraklMockedHttpClient extends MockHttpClient
                             $this->getMiraklOrder('old_order_failed_transfer'),
                         ],
                     ]));
+                case '/orders?customer_debited=true&order_ids=':
+                    return new MockResponse($this->getJsonMiraklOrders());
                 case '/orders?commercial_ids=Order_66%2COrder_42':
                     return new MockResponse($this->getJsonOrdersWithCommercialId());
                 case '/shops':
@@ -215,6 +217,15 @@ class MiraklMockedHttpClient extends MockHttpClient
     }
 
     private function getJsonMiraklOrders()
+    {
+        return json_encode([
+            'orders' => [
+                $this->getMiraklOrder('order_4'),
+            ],
+        ]);
+    }
+
+    private function getJsonMiraklAllOrders()
     {
         return json_encode([
             'orders' => [


### PR DESCRIPTION
Hi folks,

there is currently a problem with `process-transfer` command. If `$failedOrderIds` is empty (no failed transactions so far) `$miraklFailedTransferOrders = $this->miraklClient->listOrdersById($failedOrderIds);` will return 10 recent orders (this is how `/orders?customer_debited=true&order_ids=` works). In that case `$miraklOrders` and `$miraklFailedTransferOrders` will contains some same orders, which `$miraklOrders = array_merge($miraklOrders, $miraklFailedTransferOrders);` will not be able to eliminate.

Bellow behaviour will cause following exception:

```
Doctrine\DBAL\Exception\UniqueConstraintViolationException : An exception occurred while executing 'INSERT INTO stripe_transfer (mirakl_id, type, transfer_id, transaction_id, amount, status, failed_reason, currency, mirakl_update_time, creation_datetime, modification_datetime, account_mapping_id) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)' with params ["order_4", "TRANSFER_ORDER", null, "ch_transaction_1", 2500, "TRANSFER_PENDING", null, "eur", "2019-09-24 14:00:40", "2020-10-20 14:50:08", "2020-10-20 14:50:08", 1]:

SQLSTATE[23000]: Integrity constraint violation: 19 UNIQUE constraint failed: stripe_transfer.type, stripe_transfer.mirakl_id
```

You can reproduce the behaviour by executing the test without the fix in `ProcessTransferCommand`.

Best regards
Artem