### PR TITLE
Fix incorrect entity finder method call

### DIFF
--- a/src/Controller/StripeWebhookEndpoint.php
+++ b/src/Controller/StripeWebhookEndpoint.php
@@ -275,7 +275,7 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
         $this->checkChargeStatus($stripeCharge);
         $stripeChargeId = $stripeCharge['id'];
 
-        $stripeCharge = $this->stripeChargeRepository->findOneByStripePaymentId($stripeChargeId);
+        $stripeCharge = $this->stripeChargeRepository->findOneByStripeChargeId($stripeChargeId);
 
         if (!$stripeCharge) {
             $stripeCharge = new StripeCharge();
@@ -301,7 +301,7 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
         if (null === $paymentIntent) {
             return null;
         }
-        
+
         if (!$paymentIntent instanceof \Stripe\PaymentIntent) {
             $paymentIntent = $this->stripeProxy->paymentIntentRetrieve($paymentIntent);
         }
@@ -315,7 +315,7 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
     private function checkAndReturnChargeMetadataOrderId(\Stripe\Charge $stripeCharge): string
     {
         if (!isset($stripeCharge['metadata'][$this->metadataOrderIdFieldName])) {
-            
+
             // Check that linked payment intent does not contain itself the metadata
             $paymentIntentMetadata = $this->checkAndReturnPaymentIntentMetadataOrderId($stripeCharge->payment_intent);
             if (null !== $paymentIntentMetadata) {

--- a/tests/Controller/StripeWebhookEndpointTest.php
+++ b/tests/Controller/StripeWebhookEndpointTest.php
@@ -65,7 +65,7 @@ class StripeWebhookEndpointTest extends TestCase
 
         $this->stripePaymentRepository = $this->getMockBuilder(StripeChargeRepository::class)
             ->disableOriginalConstructor()
-            ->setMethods(['findOneByStripePaymentId', 'persistAndFlush'])
+            ->setMethods(['findOneByStripeChargeId', 'persistAndFlush'])
             ->getMock();
 
         $logger = new NullLogger();
@@ -660,7 +660,7 @@ class StripeWebhookEndpointTest extends TestCase
         $this
             ->stripePaymentRepository
             ->expects($this->once())
-            ->method('findOneByStripePaymentId')
+            ->method('findOneByStripeChargeId')
             ->with($stripePaymentIntentId)
             ->willReturn(null);
 
@@ -727,7 +727,7 @@ class StripeWebhookEndpointTest extends TestCase
         $this
             ->stripePaymentRepository
             ->expects($this->once())
-            ->method('findOneByStripePaymentId')
+            ->method('findOneByStripeChargeId')
             ->with($stripePaymentIntentId)
             ->willReturn(null);
 
@@ -802,7 +802,7 @@ class StripeWebhookEndpointTest extends TestCase
         $this
             ->stripePaymentRepository
             ->expects($this->once())
-            ->method('findOneByStripePaymentId')
+            ->method('findOneByStripeChargeId')
             ->with($stripeChargeId)
             ->willReturn(null);
 
@@ -865,7 +865,7 @@ class StripeWebhookEndpointTest extends TestCase
         $this
             ->stripePaymentRepository
             ->expects($this->once())
-            ->method('findOneByStripePaymentId')
+            ->method('findOneByStripeChargeId')
             ->with($stripeChargeId)
             ->willReturn(null);
 
@@ -928,7 +928,7 @@ class StripeWebhookEndpointTest extends TestCase
         $this
             ->stripePaymentRepository
             ->expects($this->once())
-            ->method('findOneByStripePaymentId')
+            ->method('findOneByStripeChargeId')
             ->with($stripeChargeId)
             ->willReturn(null);
 


### PR DESCRIPTION
With the update to using charges there was a column rename in the `StripeCharge` entity which has changed the repository finder method name.

Currently in response to webhooks from Stripe we see the following errors:

> Entity 'App\Entity\StripeCharge' has no field 'stripePaymentId'. You can therefore not call 'findOneByStripePaymentId' on the entities' repository



