### PR TITLE
Rename sequence to match code naming

### DIFF
--- a/src/Migrations/Version20201214162347.php
+++ b/src/Migrations/Version20201214162347.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20201214162347 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Rename payment_id sequence to match previous renaming of object in code';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER SEQUENCE IF EXISTS stripe_payment_id_seq RENAME TO stripe_charge_id_seq;');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER SEQUENCE IF EXISTS stripe_charge_id_seq RENAME TO stripe_payment_id_seq;');
+    }
+}


### PR DESCRIPTION
Hi! 

As pointed out by @christophersjchow (thanks!) in issue #44, we forgot to rename the sequence when renaming from `StripePayment` to `StripeCharge`.

This should make the database cleaner.