### PR TITLE
v2 beta: Rename onboarding account tables to align with entity changes

### DIFF
--- a/src/Migrations/004-rename-onboarding-table.patch
+++ b/src/Migrations/004-rename-onboarding-table.patch
@@ -1,0 +1,38 @@
+diff --git a/src/Migrations/Version20210128013612.php b/src/Migrations/Version20210128013612.php
+new file mode 100644
+index 0000000..18b2dcc
+--- /dev/null
++++ b/src/Migrations/Version20210128013612.php
+@@ -0,0 +1,32 @@
++<?php
++
++declare(strict_types=1);
++
++namespace DoctrineMigrations;
++
++use Doctrine\DBAL\Schema\Schema;
++use Doctrine\Migrations\AbstractMigration;
++
++final class Version20210128013612 extends AbstractMigration
++{
++    public function getDescription() : string
++    {
++        return '';
++    }
++
++    public function up(Schema $schema) : void
++    {
++        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
++
++        $this->addSql('ALTER TABLE onboarding_account RENAME TO account_onboarding;');
++        $this->addSql('ALTER SEQUENCE onboarding_account_id_seq RENAME TO account_onboarding_id_seq;');
++    }
++
++    public function down(Schema $schema) : void
++    {
++        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
++
++        $this->addSql('ALTER TABLE account_onboarding RENAME TO onboarding_account;');
++        $this->addSql('ALTER SEQUENCE account_onboarding_id_seq RENAME TO onboarding_account_id_seq;');
++    }
++}


### PR DESCRIPTION
The entity was changed to `AccountOnboarding`. Rename tables and sequence.