### PR TITLE
v2 beta: Fix canceled orders total

### DIFF
--- a/src/Entity/MiraklProductOrder.php
+++ b/src/Entity/MiraklProductOrder.php
@@ -81,8 +81,7 @@ class MiraklProductOrder extends MiraklOrder
                     $amount += (float) $this->getOrderLineTaxes($orderLine);
                     break;
                 case 'CANCELED':
-                    $amount += (float) $orderLine['cancelations']['amount'];
-                    $amount += (float) $this->getOrderLineTaxes($orderLine['cancelations']);
+                    $amount += (float) $this->getOrderLineCanceledAmountWithTaxes($orderLine['cancelations']);
                     break;
             }
         }
@@ -129,5 +128,16 @@ class MiraklProductOrder extends MiraklOrder
         }
 
         return $taxes;
+    }
+
+    protected function getOrderLineCanceledAmountWithTaxes(array $canceledOrderLines): float
+    {
+        $canceledAmount = 0;
+        foreach ($canceledOrderLines as $orderLine) {
+            $canceledAmount += (float) $orderLine['amount'];
+            $canceledAmount += $this->getOrderLineTaxes($orderLine);
+        }
+
+        return $canceledAmount;
     }
 }


### PR DESCRIPTION
Fixes #51 

The `cancelations` field in the order lines is an array. Properly loop over the array to total the canceled amounts.