### PR TITLE
Fix serialization of array query params on service endpoints

### DIFF
--- a/src/Service/MiraklClient.php
+++ b/src/Service/MiraklClient.php
@@ -231,7 +231,7 @@ class MiraklClient
     // SOR11 by order_id
     public function listServiceOrdersById(array $orderIds)
     {
-        $res = $this->paginateByPage('/api/mms/orders', [ 'order_id' => $orderIds ], 'data');
+        $res = $this->paginateByPage('/api/mms/orders', [ 'order_id' => implode(',', $orderIds) ], 'data');
         $res = $this->arraysToObjects($res, MiraklServiceOrder::class);
         return $this->objectsToMap($res, 'getId');
     }
@@ -239,7 +239,7 @@ class MiraklClient
     // SOR11 by commercial_id
     public function listServiceOrdersByCommercialId(array $commercialIds)
     {
-        $res = $this->paginateByPage('/api/mms/orders', [ 'commercial_order_id' => $commercialIds ], 'data');
+        $res = $this->paginateByPage('/api/mms/orders', [ 'commercial_order_id' => implode(',', $commercialIds) ], 'data');
         $res = $this->arraysToObjects($res, MiraklServiceOrder::class);
         return $this->objectsToMap($res, 'getCommercialId', 'getId');
     }
@@ -255,7 +255,7 @@ class MiraklClient
     // SPA11 by order ID
     public function listServicePendingDebitsByOrderIds(array $orderIds)
     {
-        $res = $this->paginateByPage('/api/mms/debits', [ 'order_id' => $orderIds ], 'data');
+        $res = $this->paginateByPage('/api/mms/debits', [ 'order_id' => implode(',', $orderIds) ], 'data');
         $res = $this->arraysToObjects($res, MiraklServicePendingDebit::class);
         return $this->objectsToMap($res, 'getOrderId');
     }

--- a/tests/MiraklMockedHttpClient.php
+++ b/tests/MiraklMockedHttpClient.php
@@ -208,11 +208,11 @@ class MiraklMockedHttpClient extends MockHttpClient
 												return [ $key => $this->mockOrdersByStartDate($isService, $date, $page) ];
 										case isset($params['order_ids']): // Product
 										case isset($params['order_id']): // Service
-												$orderIds = $params['order_id'] ?? explode(',', $params['order_ids']);
+												$orderIds = isset($params['order_id']) ? explode(',', $params['order_id']) : explode(',', $params['order_ids']);
 												return [ $key => $this->mockOrdersById($isService, $orderIds) ];
 										case isset($params['commercial_ids']): // Product
 										case isset($params['commercial_order_id']): // Service
-												$commercialIds = $params['commercial_order_id'] ?? explode(',', $params['commercial_ids']);
+												$commercialIds = isset($params['commercial_order_id']) ? explode(',', $params['commercial_order_id']) : explode(',', $params['commercial_ids']);
 												return [ $key => $this->mockOrdersByCommercialId($isService, $commercialIds) ];
 										default:
 												return [ $key => [] ];
@@ -224,7 +224,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 								$isService = $isService ?? false;
 								switch (true) {
 										case isset($params['order_id']):
-												return [ 'data' => $this->mockPendingDebitsByOrderIds($params['order_id']) ];
+												return [ 'data' => $this->mockPendingDebitsByOrderIds(explode(',', $params['order_id'])) ];
 										case 'GET' === $method:
 												$pendingDebits = $this->mockPendingDebits($isService, $page);
 												if ($isService) {


### PR DESCRIPTION
On service endpoints that can be requested by order ids (/api/mms/orders and /api/mms/debits) the parameter is not serialized as expected by Mirakl (a string of comma separated ids). Instead it is passed to the Symfony HTTP client as an array, which end up serialized as `order_id[0]=Order1&order_id[1]=Order2` etc.

On Mirakl side this those arguments are not taken into account so all objects are returned instead of the ones actually requested. The consequence is that everytime a service order is requested by id, the connector takes the first object returned by Mirakl which is not the one that was actually requested.