### PR TITLE
Fix query param arrays using multiple keys for services

### DIFF
--- a/src/Service/MiraklClient.php
+++ b/src/Service/MiraklClient.php
@@ -86,7 +86,8 @@ class MiraklClient
         return $body;
     }
 
-    private function serializeArrayForServiceEndpoint(string $key, array $values): string {
+    private function serializeArrayForServiceEndpoint(string $key, array $values): string
+    {
         $queryString = array();
         foreach ($values as $value) {
             $queryString[] = urlencode($key) . '=' . urlencode($value);

--- a/src/Service/MiraklClient.php
+++ b/src/Service/MiraklClient.php
@@ -86,6 +86,14 @@ class MiraklClient
         return $body;
     }
 
+    private function serializeArrayForServiceEndpoint(string $key, array $values): string {
+        $queryString = array();
+        foreach ($values as $value) {
+            $queryString[] = urlencode($key) . '=' . urlencode($value);
+        }
+        return implode('&', $queryString);
+    }
+
     public function getNextLink(ResponseInterface $response)
     {
         static $nexLinkPattern = '/<([^>]+)>;\s*rel="next"/';
@@ -231,7 +239,7 @@ class MiraklClient
     // SOR11 by order_id
     public function listServiceOrdersById(array $orderIds)
     {
-        $res = $this->paginateByPage('/api/mms/orders', [ 'order_id' => implode(',', $orderIds) ], 'data');
+        $res = $this->paginateByPage('/api/mms/orders?' . $this->serializeArrayForServiceEndpoint('order_id', $orderIds), [], 'data');
         $res = $this->arraysToObjects($res, MiraklServiceOrder::class);
         return $this->objectsToMap($res, 'getId');
     }
@@ -239,7 +247,7 @@ class MiraklClient
     // SOR11 by commercial_id
     public function listServiceOrdersByCommercialId(array $commercialIds)
     {
-        $res = $this->paginateByPage('/api/mms/orders', [ 'commercial_order_id' => implode(',', $commercialIds) ], 'data');
+        $res = $this->paginateByPage('/api/mms/orders?' . $this->serializeArrayForServiceEndpoint('commercial_order_id', $commercialIds), [], 'data');
         $res = $this->arraysToObjects($res, MiraklServiceOrder::class);
         return $this->objectsToMap($res, 'getCommercialId', 'getId');
     }
@@ -255,7 +263,7 @@ class MiraklClient
     // SPA11 by order ID
     public function listServicePendingDebitsByOrderIds(array $orderIds)
     {
-        $res = $this->paginateByPage('/api/mms/debits', [ 'order_id' => implode(',', $orderIds) ], 'data');
+        $res = $this->paginateByPage('/api/mms/debits?' . $this->serializeArrayForServiceEndpoint('order_id', $orderIds), [], 'data');
         $res = $this->arraysToObjects($res, MiraklServicePendingDebit::class);
         return $this->objectsToMap($res, 'getOrderId');
     }


### PR DESCRIPTION
Arrays in query strings for services do not use the same format as products. Instead of `order_id=order1,order2` it should be `order_id=order1&order_id=order2`.

Symfony cannot handle this format natively as it relies on http_build_query. Instead I used a solution based on https://stackoverflow.com/questions/17161114/php-http-build-query-with-two-array-keys-that-are-same. It still merges the "hardcoded" parts with the dynamic params like "limit".