### PR TITLE
Install Filebeat

### DIFF
--- a/config/packages/dev/monolog.yaml
+++ b/config/packages/dev/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['onboarding', 'pending_debit', 'process_transfer', 'process_refund', 'process_payout', 'failed_operation']
     handlers:
         main:
             type: stream

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -8,6 +8,7 @@ monolog:
         nested:
             type: stream
             path: "%kernel.logs_dir%/%kernel.environment%.log"
+            formatter: json_log_formatter
             level: info
         console:
             type: console

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -6,10 +6,11 @@ monolog:
             handler: nested
             excluded_http_codes: [404, 405]
         nested:
-            type: stream
+            type: rotating_file
             path: "%kernel.logs_dir%/%kernel.environment%.log"
             formatter: json_log_formatter
             level: info
+            max_files: 10
         console:
             type: console
             process_psr_3_messages: false

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -7,7 +7,7 @@ monolog:
             excluded_http_codes: [404, 405]
         nested:
             type: stream
-            path: "php://stderr"
+            path: "%kernel.logs_dir%/%kernel.environment%.log"
             level: info
         console:
             type: console

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -11,9 +11,6 @@ monolog:
             formatter: json_log_formatter
             level: info
             max_files: 10
-        console:
-            type: console
-            process_psr_3_messages: false
             channels: ["!event", "!doctrine", "!messenger"]
 
         critical_mail:

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -14,7 +14,7 @@ monolog:
         console:
             type: console
             process_psr_3_messages: false
-            channels: ["!event", "!doctrine"]
+            channels: ["!event", "!doctrine", "!messenger"]
 
         critical_mail:
             type:         fingers_crossed

--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['onboarding', 'pending_debit', 'process_transfer', 'process_refund', 'process_payout', 'failed_operation']
     handlers:
         main:
             type: fingers_crossed

--- a/config/packages/test/monolog.yaml
+++ b/config/packages/test/monolog.yaml
@@ -1,4 +1,5 @@
 monolog:
+    channels: ['onboarding', 'pending_debit', 'process_transfer', 'process_refund', 'process_payout', 'failed_operation']
     handlers:
         main:
             type: stream

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -126,3 +126,6 @@ services:
       $messageFactory: '@symfony_mailer_monolog.mail_message_factory'
       $level: 'warning'
       $bubble: true
+
+  json_log_formatter:
+    class: Monolog\Formatter\JsonFormatter

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -129,3 +129,27 @@ services:
 
   json_log_formatter:
     class: Monolog\Formatter\JsonFormatter
+
+  App\Command\AccountOnboardingCommand:
+    calls:
+        - setLogger: ['@monolog.logger.onboarding']
+
+  App\Command\AlertingCommand:
+    calls:
+        - setLogger: ['@monolog.logger.failed_operation']
+
+  App\Command\PaymentRefundCommand:
+    calls:
+        - setLogger: ['@monolog.logger.process_refund']
+
+  App\Command\PaymentSplitCommand:
+    calls:
+        - setLogger: ['@monolog.logger.process_transfer']
+
+  App\Command\PaymentValidationCommand:
+    calls:
+        - setLogger: ['@monolog.logger.pending_debit']
+
+  App\Command\SellerSettlementCommand:
+    calls:
+        - setLogger: ['@monolog.logger.process_payout']

--- a/examples/docker/app/Dockerfile
+++ b/examples/docker/app/Dockerfile
@@ -57,5 +57,8 @@ RUN curl -fsSLO "$SUPERCRONIC_URL" \
 RUN mkdir /var/log/supervisor
 RUN chown -R nobody /var/log/supervisor
 
+# Add nginx logrotate
+COPY examples/docker/app/config/nginxlogrotate /etc/logrotate.d/nginx
+
 # Switch to use a non-root user from here on
 USER nobody

--- a/examples/docker/app/Dockerfile
+++ b/examples/docker/app/Dockerfile
@@ -7,12 +7,24 @@ ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.
 USER root
 
 # Install packages
-RUN apk add postgresql php7-pdo_pgsql php7-iconv php7-tokenizer php7-pcntl php7-gmp --no-cache
+RUN apk add postgresql php7-pdo_pgsql php7-iconv php7-tokenizer php7-pcntl php7-gmp libc6-compat curl jq --no-cache
+
+# Install filebeat
+RUN \
+    cd /tmp \
+    && wget https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.12.0-linux-x86_64.tar.gz \
+    && tar xzvf filebeat-7.12.0-linux-x86_64.tar.gz \
+    && mv filebeat-7.12.0-linux-x86_64 /usr/share/filebeat \
+    && mkdir /usr/share/filebeat/logs /usr/share/filebeat/data \
+    && rm /tmp/*
+ENV PATH $PATH:/usr/share/filebeat
+RUN chown -R nobody /usr/share/filebeat
 
 # Install composer
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Copy configuration files
+COPY examples/docker/app/config/filebeat.yml /usr/share/filebeat/filebeat.yml
 COPY examples/docker/app/config/php.ini /etc/php7/conf.d/settings.ini
 COPY examples/docker/app/config/nginx.conf /etc/nginx/nginx.conf
 COPY examples/docker/app/certs/* /etc/letsencrypt/
@@ -36,10 +48,14 @@ RUN composer dump-autoload --no-scripts --no-dev --optimize -q \
 
 # Install supercronic (for crons)
 RUN curl -fsSLO "$SUPERCRONIC_URL" \
- && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
- && chmod +x "$SUPERCRONIC" \
- && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
- && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+    && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
+    && chmod +x "$SUPERCRONIC" \
+    && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \
+    && ln -s "/usr/local/bin/${SUPERCRONIC}" /usr/local/bin/supercronic
+
+# Create supervisor log directory and let nobody user read it
+RUN mkdir /var/log/supervisor
+RUN chown -R nobody /var/log/supervisor
 
 # Switch to use a non-root user from here on
 USER nobody

--- a/examples/docker/app/Dockerfile
+++ b/examples/docker/app/Dockerfile
@@ -1,8 +1,8 @@
 FROM trafex/alpine-nginx-php7:latest
 
-ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.9/supercronic-linux-amd64 \
+ENV SUPERCRONIC_URL=https://github.com/aptible/supercronic/releases/download/v0.1.12/supercronic-linux-amd64 \
     SUPERCRONIC=supercronic-linux-amd64 \
-    SUPERCRONIC_SHA1SUM=5ddf8ea26b56d4a7ff6faecdd8966610d5cb9d85
+    SUPERCRONIC_SHA1SUM=048b95b48b708983effb2e5c935a1ef8483d9e3e
 
 USER root
 

--- a/examples/docker/app/config/crontab
+++ b/examples/docker/app/config/crontab
@@ -1,12 +1,12 @@
 # Every minute.
-*       *       *   *       *       php /var/www/bin/console connector:sync:onboarding 5 2>&1
+*       *       *   *       *       php /var/www/bin/console connector:sync:onboarding 5 > /dev/null 2>&1
 # Every 5 minutes starting from 0. E.g. 10:00.
-0-59/5  *       *   *       *       php /var/www/bin/console connector:validate:pending-debit -q 2>&1
+0-59/5  *       *   *       *       php /var/www/bin/console connector:validate:pending-debit -q > /dev/null 2>&1
 # Every 5 minutes starting from 1. E.g. 10:01.
-1-59/5  *       *   *       *       php /var/www/bin/console connector:dispatch:process-transfer -q 2>&1
+1-59/5  *       *   *       *       php /var/www/bin/console connector:dispatch:process-transfer -q > /dev/null 2>&1
 # Every 5 minutes starting from 2. E.g. 10:02.
-2-59/5  *       *   *       *       php /var/www/bin/console connector:dispatch:process-refund -q 2>&1
+2-59/5  *       *   *       *       php /var/www/bin/console connector:dispatch:process-refund -q > /dev/null 2>&1
 # Every day at 01:03.
-3       1       *   *       *       php /var/www/bin/console connector:dispatch:process-payout -q 2>&1
+3       1       *   *       *       php /var/www/bin/console connector:dispatch:process-payout -q > /dev/null 2>&1
 # Every day at 08:04.
-4       8       *   *       *       php /var/www/bin/console connector:notify:failed-operation -q 2>&1
+4       8       *   *       *       php /var/www/bin/console connector:notify:failed-operation -q > /dev/null 2>&1

--- a/examples/docker/app/config/filebeat.yml
+++ b/examples/docker/app/config/filebeat.yml
@@ -1,0 +1,34 @@
+# ============================== Filebeat inputs ===============================
+filebeat.inputs:
+- type: log 
+  paths:
+    - /var/www/var/log/*.log
+  fields:
+    emitter: "symfony"
+  fields_under_root: true
+  json:
+    keys_under_root: true
+    overwrite_keys: true
+
+- type: log
+  paths:
+    - /var/log/nginx/*.log
+  fields:
+    emitter: "nginx"
+  fields_under_root: true
+
+- type: log
+  paths:
+    - /var/log/supervisor/*.log
+  fields:
+    emitter: "supervisor"
+  fields_under_root: true
+
+# ============================== Filebeat outputs ===============================
+# Output to console by default, configure your own destination below
+# https://www.elastic.co/guide/en/beats/filebeat/current/configuring-output.html
+
+output.console:
+
+#cloud.id: ""
+#cloud.auth: ""

--- a/examples/docker/app/config/filebeat.yml
+++ b/examples/docker/app/config/filebeat.yml
@@ -4,7 +4,7 @@ filebeat.inputs:
   paths:
     - /var/www/var/log/*.log
   fields:
-    emitter: "symfony"
+    emitter: "SYMFONY"
   fields_under_root: true
   json:
     keys_under_root: true
@@ -12,16 +12,50 @@ filebeat.inputs:
 
 - type: log
   paths:
-    - /var/log/nginx/*.log
+    - /var/log/nginx/error.log
   fields:
-    emitter: "nginx"
+    emitter: "NGINX"
+    level_name: "ERROR"
   fields_under_root: true
 
 - type: log
   paths:
-    - /var/log/supervisor/*.log
+    - /var/log/nginx/access.log
   fields:
-    emitter: "supervisor"
+    emitter: "NGINX"
+    level_name: "INFO"
+  fields_under_root: true
+
+- type: log
+  paths:
+    - /var/log/supervisor/cron.log
+    - /var/log/supervisor/operator_http_notification.log
+    - /var/log/supervisor/operator_http_notification_failed.log
+    - /var/log/supervisor/validate_mirakl_order.log
+    - /var/log/supervisor/capture_pending_payment.log
+    - /var/log/supervisor/cancel_pending_payment.log
+    - /var/log/supervisor/process_transfers.log
+    - /var/log/supervisor/process_payouts.log
+    - /var/log/supervisor/process_refunds.log
+  fields:
+    emitter: "SUPERVISOR"
+    level_name: "INFO"
+  fields_under_root: true
+
+- type: log
+  paths:
+    - /var/log/supervisor/cron-error.log
+    - /var/log/supervisor/operator_http_notification-error.log
+    - /var/log/supervisor/operator_http_notification_failed-error.log
+    - /var/log/supervisor/validate_mirakl_order-error.log
+    - /var/log/supervisor/capture_pending_payment-error.log
+    - /var/log/supervisor/cancel_pending_payment-error.log
+    - /var/log/supervisor/process_transfers-error.log
+    - /var/log/supervisor/process_payouts-error.log
+    - /var/log/supervisor/process_refunds-error.log
+  fields:
+    emitter: "SUPERVISOR"
+    level_name: "ERROR"
   fields_under_root: true
 
 # ============================== Filebeat outputs ===============================
@@ -29,6 +63,8 @@ filebeat.inputs:
 # https://www.elastic.co/guide/en/beats/filebeat/current/configuring-output.html
 
 output.console:
-
+  codec.format:
+    string: '[%{[emitter]}] %{[@timestamp]} %{[level_name]}: %{[message]}'
+    escape_html: false
 #cloud.id: ""
 #cloud.auth: ""

--- a/examples/docker/app/config/filebeat.yml
+++ b/examples/docker/app/config/filebeat.yml
@@ -41,7 +41,9 @@ filebeat.inputs:
     emitter: "SUPERVISOR"
     level_name: "INFO"
   fields_under_root: true
-
+  json:
+    keys_under_root: true
+    overwrite_keys: true
 - type: log
   paths:
     - /var/log/supervisor/cron-error.log
@@ -57,6 +59,64 @@ filebeat.inputs:
     emitter: "SUPERVISOR"
     level_name: "ERROR"
   fields_under_root: true
+  json:
+    keys_under_root: true
+    overwrite_keys: true
+
+# For Supervisor logs, rename msg field to message and add human readable job_name field
+processors:
+  - if:
+      equals:
+        emitter: "SUPERVISOR"
+    then:
+      - rename:
+          fields:
+            - from: "msg"
+              to: "message"
+          ignore_missing: true
+          fail_on_error: false
+      - add_fields:
+          when:
+            contains:
+              job.command: "onboarding"
+          target: ""
+          fields:
+            job_name: "Onboarding"
+      - add_fields:
+          when:
+            contains:
+              job.command: "pending-debit"
+          target: ""
+          fields:
+            job_name: "Pending Debit"
+      - add_fields:
+          when:
+            contains:
+              job.command: "process-transfer"
+          target: ""
+          fields:
+            job_name: "Process Transfer"
+      - add_fields:
+          when:
+            contains:
+              job.command: "process-refund"
+          target: ""
+          fields:
+            job_name: "Process Refund"
+      - add_fields:
+          when:
+            contains:
+              job.command: "process-payout"
+          target: ""
+          fields:
+            job_name: "Process Payout"
+      - add_fields:
+          when:
+            contains:
+              job.command: "failed-operation"
+          target: ""
+          fields:
+            job_name: "Failed Operation"
 
 # ============================== Filebeat outputs ===============================
 # Output to console by default, configure your own destination below
@@ -64,7 +124,7 @@ filebeat.inputs:
 
 output.console:
   codec.format:
-    string: '[%{[emitter]}] %{[@timestamp]} %{[level_name]}: %{[message]}'
+    string: '[%{[emitter]}] %{[@timestamp]} %{[level_name]}: [%{[job_name]:}] %{[message]}'
     escape_html: false
 #cloud.id: ""
 #cloud.auth: ""

--- a/examples/docker/app/config/filebeat.yml
+++ b/examples/docker/app/config/filebeat.yml
@@ -82,42 +82,42 @@ processors:
               job_name: "onboarding"
           target: ""
           fields:
-            job_name: "Onboarding"
+            job_name: "Sellers onboarding"
       - add_fields:
           when:
             equals:
               job_name: "pending_debit"
           target: ""
           fields:
-            job_name: "Pending Debit"
+            job_name: "Payments validation"
       - add_fields:
           when:
             equals:
               job_name: "process_transfer"
           target: ""
           fields:
-            job_name: "Process Transfer"
+            job_name: "Payments split"
       - add_fields:
           when:
             equals:
               job_name: "process_refund"
           target: ""
           fields:
-            job_name: "Process Refund"
+            job_name: "Payments refund"
       - add_fields:
           when:
             equals:
               job_name: "process_payout"
           target: ""
           fields:
-            job_name: "Process Payout"
+            job_name: "Seller settlement"
       - add_fields:
           when:
             equals:
               job_name: "failed_operation"
           target: ""
           fields:
-            job_name: "Failed Operation"
+            job_name: "Alerting"
 
 # For Supervisor logs, rename msg field to message and add human readable job_name field
   - if:
@@ -136,42 +136,42 @@ processors:
               job.command: "onboarding"
           target: ""
           fields:
-            job_name: "Onboarding"
+            job_name: "Sellers onboarding"
       - add_fields:
           when:
             contains:
               job.command: "pending-debit"
           target: ""
           fields:
-            job_name: "Pending Debit"
+            job_name: "Payments validation"
       - add_fields:
           when:
             contains:
               job.command: "process-transfer"
           target: ""
           fields:
-            job_name: "Process Transfer"
+            job_name: "Payments split"
       - add_fields:
           when:
             contains:
               job.command: "process-refund"
           target: ""
           fields:
-            job_name: "Process Refund"
+            job_name: "Payments refund"
       - add_fields:
           when:
             contains:
               job.command: "process-payout"
           target: ""
           fields:
-            job_name: "Process Payout"
+            job_name: "Seller settlement"
       - add_fields:
           when:
             contains:
               job.command: "failed-operation"
           target: ""
           fields:
-            job_name: "Failed Operation"
+            job_name: "Alerting"
 
 # ============================== Filebeat outputs ===============================
 # Output to console by default, configure your own destination below

--- a/examples/docker/app/config/filebeat.yml
+++ b/examples/docker/app/config/filebeat.yml
@@ -63,8 +63,63 @@ filebeat.inputs:
     keys_under_root: true
     overwrite_keys: true
 
-# For Supervisor logs, rename msg field to message and add human readable job_name field
+
 processors:
+# For Symfony logs, rename channel field to job_name and make it human readable
+  - if:
+      equals:
+        emitter: "SYMFONY"
+    then:
+      - rename:
+          fields:
+            - from: "channel"
+              to: "job_name"
+          ignore_missing: true
+          fail_on_error: false
+      - add_fields:
+          when:
+            equals:
+              job_name: "onboarding"
+          target: ""
+          fields:
+            job_name: "Onboarding"
+      - add_fields:
+          when:
+            equals:
+              job_name: "pending_debit"
+          target: ""
+          fields:
+            job_name: "Pending Debit"
+      - add_fields:
+          when:
+            equals:
+              job_name: "process_transfer"
+          target: ""
+          fields:
+            job_name: "Process Transfer"
+      - add_fields:
+          when:
+            equals:
+              job_name: "process_refund"
+          target: ""
+          fields:
+            job_name: "Process Refund"
+      - add_fields:
+          when:
+            equals:
+              job_name: "process_payout"
+          target: ""
+          fields:
+            job_name: "Process Payout"
+      - add_fields:
+          when:
+            equals:
+              job_name: "failed_operation"
+          target: ""
+          fields:
+            job_name: "Failed Operation"
+
+# For Supervisor logs, rename msg field to message and add human readable job_name field
   - if:
       equals:
         emitter: "SUPERVISOR"

--- a/examples/docker/app/config/nginx.conf
+++ b/examples/docker/app/config/nginx.conf
@@ -16,8 +16,8 @@ http {
                           '"$http_user_agent" "$http_x_forwarded_for" '
                           '$request_time $upstream_response_time $pipe $upstream_cache_status';
 
-    access_log /dev/stdout main_timed;
-    error_log /dev/stderr notice;
+    access_log logs/access.log main_timed;
+    error_log logs/error.log notice;
 
     keepalive_timeout 65;
 

--- a/examples/docker/app/config/nginxlogrotate
+++ b/examples/docker/app/config/nginxlogrotate
@@ -1,0 +1,8 @@
+/var/log/nginx/*.log {
+        weekly
+        missingok
+        sharedscripts
+        postrotate
+                /etc/init.d/nginx --quiet --ifstarted reopen
+        endscript
+}

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -1,80 +1,80 @@
 [program:cron]
 stdout_logfile=/var/log/supervisor/cron.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/cron-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=supercronic /etc/crontabs/connector-crontab
 
 [program:php-command-operator_http_notification]
 stdout_logfile=/var/log/supervisor/operator_http_notification.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/operator_http_notification-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume operator_http_notification update_login_link update_kyc_status --time-limit=3600 --env=prod --quiet
 
 [program:php-command-operator_http_notification_failed]
 stdout_logfile=/var/log/supervisor/operator_http_notification_failed.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/operator_http_notification_failed-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume operator_http_notification_failed --time-limit=3600 --env=prod --quiet
 
 [program:php-command-validate_mirakl_order]
 stdout_logfile=/var/log/supervisor/validate_mirakl_order.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/validate_mirakl_order-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume validate_mirakl_order --time-limit=3600 --env=prod --quiet
 
 [program:php-command-capture_pending_payment]
 stdout_logfile=/var/log/supervisor/capture_pending_payment.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/capture_pending_payment-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume capture_pending_payment --time-limit=3600 --env=prod --quiet
 
 [program:php-command-cancel_pending_payment]
 stdout_logfile=/var/log/supervisor/cancel_pending_payment.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/cancel_pending_payment-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume cancel_pending_payment --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_transfers]
 stdout_logfile=/var/log/supervisor/process_transfers.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/process_transfers-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_transfers --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_payouts]
 stdout_logfile=/var/log/supervisor/process_payouts.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/process_payouts-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_payouts --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_refunds]
 stdout_logfile=/var/log/supervisor/process_refunds.log
-stdout_logfile_maxbytes=0
+stdout_logfile_maxbytes=10MB
 stderr_logfile=/var/log/supervisor/process_refunds-error.log
-stderr_logfile_maxbytes=0
+stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_refunds --time-limit=3600 --env=prod --quiet

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -78,3 +78,12 @@ stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_refunds --time-limit=3600 --env=prod --quiet
+
+[program:filebeat]
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+autostart=true
+autorestart=true
+command=/usr/share/filebeat/filebeat -c /usr/share/filebeat/filebeat.yml

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -1,80 +1,79 @@
-
 [program:cron]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/cron.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/cron-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=supercronic /etc/crontabs/connector-crontab
 
 [program:php-command-operator_http_notification]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/operator_http_notification.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/operator_http_notification-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume operator_http_notification update_login_link update_kyc_status --time-limit=3600 --env=prod --quiet
 
 [program:php-command-operator_http_notification_failed]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/operator_http_notification_failed.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/operator_http_notification_failed-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume operator_http_notification_failed --time-limit=3600 --env=prod --quiet
 
 [program:php-command-validate_mirakl_order]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/validate_mirakl_order.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/validate_mirakl_order-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume validate_mirakl_order --time-limit=3600 --env=prod --quiet
 
 [program:php-command-capture_pending_payment]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/capture_pending_payment.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/capture_pending_payment-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume capture_pending_payment --time-limit=3600 --env=prod --quiet
 
 [program:php-command-cancel_pending_payment]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/cancel_pending_payment.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/cancel_pending_payment-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume cancel_pending_payment --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_transfers]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/process_transfers.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/process_transfers-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_transfers --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_payouts]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/process_payouts.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/process_payouts-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true
 command=php /var/www/bin/console messenger:consume process_payouts --time-limit=3600 --env=prod --quiet
 
 [program:php-command-process_refunds]
-stdout_logfile=/dev/stdout
+stdout_logfile=/var/log/supervisor/process_refunds.log
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
+stderr_logfile=/var/log/supervisor/process_refunds-error.log
 stderr_logfile_maxbytes=0
 autostart=true
 autorestart=true

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -5,7 +5,7 @@ stderr_logfile=/var/log/supervisor/cron-error.log
 stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
-command=supercronic /etc/crontabs/connector-crontab
+command=supercronic -split-logs /etc/crontabs/connector-crontab
 
 [program:php-command-operator_http_notification]
 stdout_logfile=/var/log/supervisor/operator_http_notification.log

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -5,7 +5,7 @@ stderr_logfile=/var/log/supervisor/cron-error.log
 stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
-command=supercronic -split-logs -json /etc/crontabs/connector-crontab
+command=supercronic -split-logs -json -quiet /etc/crontabs/connector-crontab
 
 [program:php-command-operator_http_notification]
 stdout_logfile=/var/log/supervisor/operator_http_notification.log

--- a/examples/docker/app/config/supervisord.conf
+++ b/examples/docker/app/config/supervisord.conf
@@ -5,7 +5,7 @@ stderr_logfile=/var/log/supervisor/cron-error.log
 stderr_logfile_maxbytes=10MB
 autostart=true
 autorestart=true
-command=supercronic -split-logs /etc/crontabs/connector-crontab
+command=supercronic -split-logs -json /etc/crontabs/connector-crontab
 
 [program:php-command-operator_http_notification]
 stdout_logfile=/var/log/supervisor/operator_http_notification.log

--- a/src/Command/AccountOnboardingCommand.php
+++ b/src/Command/AccountOnboardingCommand.php
@@ -66,7 +66,7 @@ class AccountOnboardingCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
-        $output->writeln('Updating Stripe Express onboarding links for new Mirakl sellers');
+        $this->logger->info('Updating Stripe Express onboarding links for new Mirakl sellers');
         $delay = intval($input->getArgument(self::DELAY_ARGUMENT_NAME));
 
         if ($delay > 0) {
@@ -78,10 +78,10 @@ class AccountOnboardingCommand extends Command implements LoggerAwareInterface
         }
 
         $shopsToCheck = $this->miraklClient->fetchShops(null, $lastMapping, false);
-        $output->writeln(sprintf('Found %d potentially new Mirakl Shops', count($shopsToCheck)));
+        $this->logger->info(sprintf('Found %d potentially new Mirakl Shops', count($shopsToCheck)));
 
         $shopsToUpdate = array_filter(array_map([$this, 'generateShopPatch'], $shopsToCheck));
-        $output->writeln(sprintf('Updating %d new Mirakl Shops', count($shopsToUpdate)));
+        $this->logger->info(sprintf('Updating %d new Mirakl Shops', count($shopsToUpdate)));
 
         if (count($shopsToUpdate) > 0) {
             $maxBatchSizeShops = array_chunk($shopsToUpdate, self::MAX_MIRAKL_BATCH_SIZE);

--- a/src/Command/AccountOnboardingCommand.php
+++ b/src/Command/AccountOnboardingCommand.php
@@ -66,6 +66,7 @@ class AccountOnboardingCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->logger->info('starting');
         $this->logger->info('Updating Stripe Express onboarding links for new Mirakl sellers');
         $delay = intval($input->getArgument(self::DELAY_ARGUMENT_NAME));
 
@@ -90,6 +91,7 @@ class AccountOnboardingCommand extends Command implements LoggerAwareInterface
             }
         }
 
+        $this->logger->info('job succeeded');
         return 0;
     }
 

--- a/src/Command/AlertingCommand.php
+++ b/src/Command/AlertingCommand.php
@@ -66,19 +66,19 @@ class AlertingCommand extends Command implements LoggerAwareInterface
 
     public function execute(InputInterface $input, OutputInterface $output): ?int
     {
-        $output->writeln('<info>Sending alert email about failed transfers, payouts and refunds</info>');
+        $this->logger->info('<info>Sending alert email about failed transfers, payouts and refunds</info>');
 
         $failedTransfers = $this->stripeTransferRepository->findBy(['status' => StripeTransfer::getInvalidStatus()]);
-        $output->writeln(sprintf('Found %d transfer(s) which failed transfering', count($failedTransfers)));
+        $this->logger->info(sprintf('Found %d transfer(s) which failed transfering', count($failedTransfers)));
 
         $failedPayouts = $this->stripePayoutRepository->findBy(['status' => StripePayout::getInvalidStatus()]);
-        $output->writeln(sprintf('Found %d payout(s) which failed transfering', count($failedPayouts)));
+        $this->logger->info(sprintf('Found %d payout(s) which failed transfering', count($failedPayouts)));
 
         $failedRefunds = $this->stripeRefundRepository->findBy(['status' => StripeRefund::getInvalidStatus()]);
-        $output->writeln(sprintf('Found %d refund(s) which failed transfering', count($failedRefunds)));
+        $this->logger->info(sprintf('Found %d refund(s) which failed transfering', count($failedRefunds)));
 
         if (0 === count($failedTransfers) && 0 === count($failedPayouts) && 0 === count($failedRefunds)) {
-            $output->writeln('Exiting');
+            $this->logger->info('Exiting');
 
             return 0;
         }
@@ -129,9 +129,9 @@ class AlertingCommand extends Command implements LoggerAwareInterface
             'technicalEmail' => $this->technicalEmail,
         ]);
 
-        $output->writeln('Sending email');
+        $this->logger->info('Sending email');
         $this->mailer->send($email);
-        $output->writeln('<info>Email sent</info>');
+        $this->logger->info('<info>Email sent</info>');
 
         return 0;
     }

--- a/src/Command/AlertingCommand.php
+++ b/src/Command/AlertingCommand.php
@@ -66,6 +66,7 @@ class AlertingCommand extends Command implements LoggerAwareInterface
 
     public function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->logger->info('starting');
         $this->logger->info('<info>Sending alert email about failed transfers, payouts and refunds</info>');
 
         $failedTransfers = $this->stripeTransferRepository->findBy(['status' => StripeTransfer::getInvalidStatus()]);
@@ -79,7 +80,7 @@ class AlertingCommand extends Command implements LoggerAwareInterface
 
         if (0 === count($failedTransfers) && 0 === count($failedPayouts) && 0 === count($failedRefunds)) {
             $this->logger->info('Exiting');
-
+            $this->logger->info('job succeeded');
             return 0;
         }
 
@@ -132,7 +133,7 @@ class AlertingCommand extends Command implements LoggerAwareInterface
         $this->logger->info('Sending email');
         $this->mailer->send($email);
         $this->logger->info('<info>Email sent</info>');
-
+        $this->logger->info('job succeeded');
         return 0;
     }
 }

--- a/src/Command/PaymentRefundCommand.php
+++ b/src/Command/PaymentRefundCommand.php
@@ -69,6 +69,7 @@ class PaymentRefundCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->logger->info('starting');
         if ($this->enableProductPaymentRefund || $this->enableServicePaymentRefund) {
             $this->processBacklog();
 
@@ -81,6 +82,7 @@ class PaymentRefundCommand extends Command implements LoggerAwareInterface
             }
         }
 
+        $this->logger->info('job succeeded');
         return 0;
     }
 

--- a/src/Command/PaymentSplitCommand.php
+++ b/src/Command/PaymentSplitCommand.php
@@ -70,6 +70,7 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->logger->info('starting');
         if ($this->enableProductPaymentSplit) {
             $this->processBacklog(MiraklClient::ORDER_TYPE_PRODUCT);
             $this->processNewOrders(MiraklClient::ORDER_TYPE_PRODUCT);
@@ -80,6 +81,7 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
             $this->processNewOrders(MiraklClient::ORDER_TYPE_SERVICE);
         }
 
+        $this->logger->info('job succeeded');
         return 0;
     }
 

--- a/src/Command/PaymentValidationCommand.php
+++ b/src/Command/PaymentValidationCommand.php
@@ -63,7 +63,7 @@ class PaymentValidationCommand extends Command implements LoggerAwareInterface
         if (!empty($ordersByCommercialId)) {
             $this->validateOrders($ordersByCommercialId);
         } else {
-            $output->writeln('No mirakl orders pending debit');
+            $this->logger->info('No mirakl orders pending debit');
         }
 
         // capture payment when mirakl order is totally validated
@@ -71,7 +71,7 @@ class PaymentValidationCommand extends Command implements LoggerAwareInterface
         if (!empty($paymentMappings)) {
             $this->capturePayments($paymentMappings);
         } else {
-            $output->writeln('No payment to capture');
+            $this->logger->info('No payment to capture');
         }
 
         return 0;

--- a/src/Command/PaymentValidationCommand.php
+++ b/src/Command/PaymentValidationCommand.php
@@ -58,6 +58,7 @@ class PaymentValidationCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output): ?int
     {
+        $this->logger->info('starting');
         // validate payment to mirakl when we have a charge/paymentIntent
         $ordersByCommercialId = $this->miraklClient->listProductPendingDebits();
         if (!empty($ordersByCommercialId)) {
@@ -74,6 +75,7 @@ class PaymentValidationCommand extends Command implements LoggerAwareInterface
             $this->logger->info('No payment to capture');
         }
 
+        $this->logger->info('job succeeded');
         return 0;
     }
 

--- a/src/Command/SellerSettlementCommand.php
+++ b/src/Command/SellerSettlementCommand.php
@@ -62,10 +62,12 @@ class SellerSettlementCommand extends Command implements LoggerAwareInterface
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->logger->info('starting');
         // Shop ID passed as argument
         $shopId = $input->getArgument('mirakl_shop_id');
         if (is_numeric($shopId)) {
             $this->processProvidedShopId((int) $shopId);
+            $this->logger->info('job succeeded');
             return 0;
         }
 
@@ -75,6 +77,7 @@ class SellerSettlementCommand extends Command implements LoggerAwareInterface
         // Now up to 100 new invoices
         $this->processNewInvoices();
 
+        $this->logger->info('job succeeded');
         return 0;
     }
 


### PR DESCRIPTION
This PR setup Filebeat in order to agregate logs from Symfony, supervisor and nginx.
Logs output is stdout by default by it can be changed for any other output in `filebeat.yml` (ElasticSearch, File,...)
Logs are grouped by emitter with a field "emitter"
Symfony logs are formatted to JSON, improving ElasticSearch indexation. Then, we can filter by error level, message, service, etc.
I configured log rotation to avoid issues with disk memory usage.