### PR TITLE
Store Mirakl shop id against Connect Account metadata

### DIFF
--- a/src/Controller/AccountMappingBySeller.php
+++ b/src/Controller/AccountMappingBySeller.php
@@ -150,6 +150,7 @@ class AccountMappingBySeller extends AbstractController implements LoggerAwareIn
             $response = $this->stripeClient->loginWithCode((string) $code);
             $stripeUserId = $response->stripe_user_id;
             $stripeAccount = $this->stripeClient->setPayoutToManual($stripeUserId);
+            $stripeAccount = $this->stripeClient->setMiraklShopId($stripeUserId, $miraklShopId);
         } catch (ApiErrorException $e) {
             return $this->getRedirectResponse([
                 'code' => $e->getStripeCode(),

--- a/src/Service/StripeClient.php
+++ b/src/Service/StripeClient.php
@@ -79,6 +79,17 @@ class StripeClient
         ]);
     }
 
+    public function setMiraklShopId(string $stripeAccountId, int $miraklShopId): Account
+    {
+        $params = [
+            'metadata' => [
+                'miraklShopId' => $miraklShopId
+            ]
+        ];
+
+        return \Stripe\Account::update($stripeAccountId, $params);
+    }
+
     public function setPayoutToManual(string $stripeAccountId): Account
     {
         $params = [

--- a/tests/Controller/AccountMappingBySellerTest.php
+++ b/tests/Controller/AccountMappingBySellerTest.php
@@ -265,6 +265,12 @@ class AccountMappingBySellerTest extends TestCase
             ->method('setPayoutToManual')
             ->with('acct_valid')
             ->willReturn($stripeAccount);
+        $this
+            ->stripeClient
+            ->expects($this->once())
+            ->method('setMiraklShopId')
+            ->with('acct_valid', 4242)
+            ->willReturn($stripeAccount);
 
         $response = $this->controller->linkShop($request);
         $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());


### PR DESCRIPTION
Stores the Mirakl shop id against the metadata of the Connect Account.

Closes #84

