### PR TITLE
Fixing file permissions filebeat.yml

### DIFF
--- a/examples/docker/app/Dockerfile
+++ b/examples/docker/app/Dockerfile
@@ -25,6 +25,7 @@ COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 # Copy configuration files
 COPY examples/docker/app/config/filebeat.yml /usr/share/filebeat/filebeat.yml
+RUN chmod go-w /usr/share/filebeat/filebeat.yml
 COPY examples/docker/app/config/php.ini /etc/php7/conf.d/settings.ini
 COPY examples/docker/app/config/nginx.conf /etc/nginx/nginx.conf
 COPY examples/docker/app/certs/* /etc/letsencrypt/


### PR DESCRIPTION
Without this fix an INFO warning is logged:

```
2021-10-25 12:24:02,523 INFO success: filebeat entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2021-10-25 12:24:02,524 INFO exited: filebeat (exit status 1; not expected)
2021-10-25 12:24:03,527 INFO spawned: 'filebeat' with pid 4516
Exiting: error loading config file: config file ("/usr/share/filebeat/filebeat.yml") can only be writable by the owner but the permissions are "-rw-rw-r--" (to fix the permissions use: 'chmod go-w /usr/share/filebeat/filebeat.yml')
2021-10-25 12:24:04,740 INFO success: filebeat entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2021-10-25 12:24:04,740 INFO exited: filebeat (exit status 1; not expected)
2021-10-25 12:24:05,744 INFO spawned: 'filebeat' with pid 4521
Exiting: error loading config file: config file ("/usr/share/filebeat/filebeat.yml") can only be writable by the owner but the permissions are "-rw-rw-r--" (to fix the permissions use: 'chmod go-w /usr/share/filebeat/filebeat.yml')
```

This small change fixes this.