### PR TITLE
Fix payment split checkpoint for service orders

### DIFF
--- a/src/Command/PaymentSplitCommand.php
+++ b/src/Command/PaymentSplitCommand.php
@@ -126,7 +126,7 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
         }
 
         // Retrieve new checkpoint
-        usort($orders, function ($o1, $o2) {
+        uasort($orders, function ($o1, $o2) {
             return strtotime($o2->getCreationDate()) - strtotime($o1->getCreationDate());
         });
         $lastOrder = current($orders);

--- a/src/Command/PaymentSplitCommand.php
+++ b/src/Command/PaymentSplitCommand.php
@@ -126,7 +126,10 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
         }
 
         // Retrieve new checkpoint
-        $lastOrder = current(array_reverse($orders));
+        usort($orders, function ($o1, $o2) {
+            return strtotime($o2->getCreationDate()) - strtotime($o1->getCreationDate());
+        });
+        $lastOrder = current($orders);
         $newCheckpoint = $lastOrder->getCreationDate();
 
         // Create and dispatch transfers

--- a/tests/Command/PaymentSplitCommandTest.php
+++ b/tests/Command/PaymentSplitCommandTest.php
@@ -128,6 +128,16 @@ class PaymentSplitCommandTest extends KernelTestCase
         $this->assertEquals(MiraklMockedHttpClient::ORDER_DATE_14_NEW_ORDERS_ALL_READY_END_DATE, $checkpoint);
     }
 
+    public function testProductOrdersCheckpoint()
+    {
+        // 3 new orders, one dispatchable
+        $this->configService->setProductPaymentSplitCheckpoint(MiraklMockedHttpClient::ORDER_DATE_3_NEW_ORDERS_1_READY);
+        $this->executeCommand();
+
+        $checkpoint = $this->configService->getProductPaymentSplitCheckpoint();
+        $this->assertEquals(MiraklMockedHttpClient::ORDER_DATE_3_NEW_ORDERS_1_READY, $checkpoint);
+    }
+
     public function testProductBacklog()
     {
         // 14 new orders, all dispatchable
@@ -180,6 +190,16 @@ class PaymentSplitCommandTest extends KernelTestCase
 
         $checkpoint = $this->configService->getServicePaymentSplitCheckpoint();
         $this->assertEquals(MiraklMockedHttpClient::ORDER_DATE_14_NEW_ORDERS_ALL_READY_END_DATE, $checkpoint);
+    }
+
+    public function testServiceOrdersCheckpoint()
+    {
+        // 3 new orders, one dispatchable
+        $this->configService->setServicePaymentSplitCheckpoint(MiraklMockedHttpClient::ORDER_DATE_3_NEW_ORDERS_1_READY);
+        $this->executeCommand();
+
+        $checkpoint = $this->configService->getServicePaymentSplitCheckpoint();
+        $this->assertEquals(date_format(\DateTime::createFromFormat(\DateTime::ATOM, MiraklMockedHttpClient::ORDER_DATE_3_NEW_ORDERS_1_READY), \Datetime::RFC3339_EXTENDED), $checkpoint);
     }
 
     public function testServiceBacklog()


### PR DESCRIPTION
When setting a the payment split checkpoint, the connector works under the assumption that orders are sorted by creation date. While this is the case for OR11 (product orders) it is not how SOR11 (service orders) behaves. We got the confirmation from Mirakl support that there is no way to sort this endpoint.

This behavior is not ideal but in order for the checkpoint to work we have to find the most recent order ourselves in memory. I did it for both product and service orders as the fix seemed cleaner to me but it should have no effect on product workflow behavior (it is already sorted by Mirakl). Feel free to comment if you have a better idea ;)