### PR TITLE
Batch pending debit calls

### DIFF
--- a/src/Command/PaymentSplitCommand.php
+++ b/src/Command/PaymentSplitCommand.php
@@ -97,7 +97,7 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
         $backlog = array_chunk($backlog, 10, true);
         $method = "list{$orderType}OrdersById";
         foreach ($backlog as $chunk) {
-            $pendingDebits = $orderType == MiraklClient::ORDER_TYPE_SERVICE ? $this->getServiceOrdersPendingDebits($chunk) : [];
+            $pendingDebits = $this->getServiceOrdersPendingDebits($chunk, $orderType);
             $this->dispatchTransfers(
                 $this->paymentSplitService->updateTransfersFromOrders(
                     $chunk,
@@ -134,7 +134,7 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
         // Create and dispatch transfers
         $orders = array_chunk($orders, 100, true);
         foreach ($orders as $chunk) {
-            $pendingDebits = $orderType == MiraklClient::ORDER_TYPE_SERVICE ? $this->getServiceOrdersPendingDebits($chunk) : [];
+            $pendingDebits = $this->getServiceOrdersPendingDebits($chunk, $orderType);
             $this->dispatchTransfers(
                 $this->paymentSplitService->getTransfersFromOrders($chunk, $pendingDebits)
             );
@@ -159,9 +159,9 @@ class PaymentSplitCommand extends Command implements LoggerAwareInterface
         }
     }
 
-    private function getServiceOrdersPendingDebits(array $orders): array
+    private function getServiceOrdersPendingDebits(array $orders, string $orderType): array
     {
-        if (count($orders) > 0) {
+        if ($orderType == MiraklClient::ORDER_TYPE_SERVICE) {
             return $this->miraklClient->listServicePendingDebitsByOrderIds(array_keys($orders));
         } else {
             return [];

--- a/src/Service/MiraklClient.php
+++ b/src/Service/MiraklClient.php
@@ -51,7 +51,7 @@ class MiraklClient
     private function parseQueryParams(array $params)
     {
         $queryString = http_build_query($params, '', '&', PHP_QUERY_RFC3986);
-        return preg_replace('/%5B[0-9]*%5D=/U', '=', $queryString);
+        return preg_replace('/%5B[[:alnum:]_-]*%5D=/U', '=', $queryString);
     }
 
     private function parseResponse(ResponseInterface $response, string ...$path)

--- a/src/Service/PaymentSplitService.php
+++ b/src/Service/PaymentSplitService.php
@@ -114,9 +114,13 @@ class PaymentSplitService
         $serviceOrders = array_filter($orders, function ($order) {
             return is_a($order, MiraklServiceOrder::class);
         });
-        $serviceOrderIds = array_map(function ($order) {
-            return $order->getId();
-        }, $serviceOrders);
-        return $this->miraklClient->listServicePendingDebitsByOrderIds($serviceOrderIds);
+        if (count($serviceOrders) > 0) {
+            $serviceOrderIds = array_map(function ($order) {
+                return $order->getId();
+            }, $serviceOrders);
+            return $this->miraklClient->listServicePendingDebitsByOrderIds($serviceOrderIds);
+        } else {
+            return [];
+        }
     }
 }

--- a/tests/Factory/StripeTransferFactoryTest.php
+++ b/tests/Factory/StripeTransferFactoryTest.php
@@ -397,7 +397,8 @@ class StripeTransferFactoryTest extends KernelTestCase
         $order = current($this->miraklClient->listServiceOrdersById([
             MiraklMock::ORDER_STATUS_ORDER_ACCEPTED
         ]));
-        $transfer = $this->stripeTransferFactory->updateFromOrder($transfer, $order);
+        $pendingDebits = $this->miraklClient->listServicePendingDebitsByOrderIds([$order->getId()]);
+        $transfer = $this->stripeTransferFactory->updateFromOrder($transfer, $order, $pendingDebits);
         $this->assertEquals(StripeTransfer::TRANSFER_PENDING, $transfer->getStatus());
     }
 

--- a/tests/Factory/StripeTransferFactoryTest.php
+++ b/tests/Factory/StripeTransferFactoryTest.php
@@ -370,6 +370,9 @@ class StripeTransferFactoryTest extends KernelTestCase
         $transfer = $this->stripeTransferFactory->createFromOrder(
             current($this->miraklClient->listServiceOrdersById([
                 MiraklMock::ORDER_BASIC
+            ])),
+            current($this->miraklClient->listServicePendingDebitsByOrderIds([
+                MiraklMock::ORDER_BASIC
             ]))
         );
 
@@ -397,8 +400,10 @@ class StripeTransferFactoryTest extends KernelTestCase
         $order = current($this->miraklClient->listServiceOrdersById([
             MiraklMock::ORDER_STATUS_ORDER_ACCEPTED
         ]));
-        $pendingDebits = $this->miraklClient->listServicePendingDebitsByOrderIds([$order->getId()]);
-        $transfer = $this->stripeTransferFactory->updateFromOrder($transfer, $order, $pendingDebits);
+        $pendingDebit = current($this->miraklClient->listServicePendingDebitsByOrderIds([
+            MiraklMock::ORDER_STATUS_ORDER_ACCEPTED
+        ]));
+        $transfer = $this->stripeTransferFactory->updateFromOrder($transfer, $order, $pendingDebit);
         $this->assertEquals(StripeTransfer::TRANSFER_PENDING, $transfer->getStatus());
     }
 
@@ -407,8 +412,11 @@ class StripeTransferFactoryTest extends KernelTestCase
         $order = current($this->miraklClient->listServiceOrdersById([
             MiraklMock::ORDER_BASIC
         ]));
+        $pendingDebit = current($this->miraklClient->listServicePendingDebitsByOrderIds([
+            MiraklMock::ORDER_BASIC
+        ]));
 
-        $transfer = $this->stripeTransferFactory->createFromOrder($order);
+        $transfer = $this->stripeTransferFactory->createFromOrder($order, $pendingDebit);
         $this->assertEquals(StripeTransfer::TRANSFER_PENDING, $transfer->getStatus());
 
         $transfer->setTransferId(StripeMock::TRANSFER_BASIC);
@@ -434,6 +442,9 @@ class StripeTransferFactoryTest extends KernelTestCase
             foreach ($consts as $const) {
                 $transfer = $this->stripeTransferFactory->createFromOrder(
                     current($this->miraklClient->listServiceOrdersById([
+                        constant("App\Tests\MiraklMockedHttpClient::ORDER_STATUS_$const")
+                    ])),
+                    current($this->miraklClient->listServicePendingDebitsByOrderIds([
                         constant("App\Tests\MiraklMockedHttpClient::ORDER_STATUS_$const")
                     ]))
                 );
@@ -462,6 +473,9 @@ class StripeTransferFactoryTest extends KernelTestCase
         $transfer = $this->stripeTransferFactory->createFromOrder(
             current($this->miraklClient->listServiceOrdersById([
                 MiraklMock::ORDER_INVALID_AMOUNT
+            ])),
+            current($this->miraklClient->listServicePendingDebitsByOrderIds([
+                MiraklMock::ORDER_INVALID_AMOUNT
             ]))
         );
         $this->assertEquals(StripeTransfer::TRANSFER_ABORTED, $transfer->getStatus());
@@ -480,6 +494,9 @@ class StripeTransferFactoryTest extends KernelTestCase
         foreach ($amounts as $const => $expectedAmount) {
             $transfer = $this->stripeTransferFactory->createFromOrder(
                 current($this->miraklClient->listServiceOrdersById([
+                    constant("App\Tests\MiraklMockedHttpClient::ORDER_AMOUNT_$const")
+                ])),
+                current($this->miraklClient->listServicePendingDebitsByOrderIds([
                     constant("App\Tests\MiraklMockedHttpClient::ORDER_AMOUNT_$const")
                 ]))
             );

--- a/tests/Service/PaymentSplitServiceTest.php
+++ b/tests/Service/PaymentSplitServiceTest.php
@@ -57,7 +57,8 @@ class PaymentSplitServiceTest extends KernelTestCase
 
         $this->paymentSplitService = new PaymentSplitService(
             $stripeTransferFactory,
-            $this->stripeTransferRepository
+            $this->stripeTransferRepository,
+            $this->miraklClient
         );
     }
 

--- a/tests/Service/PaymentSplitServiceTest.php
+++ b/tests/Service/PaymentSplitServiceTest.php
@@ -77,7 +77,8 @@ class PaymentSplitServiceTest extends KernelTestCase
                 MiraklMockedHttpClient::ORDER_STATUS_WAITING_DEBIT_PAYMENT,
                 MiraklMockedHttpClient::ORDER_STATUS_REFUSED,
                 MiraklMockedHttpClient::ORDER_STATUS_RECEIVED
-            ])
+            ]),
+            []
         );
         $this->assertCount(4, $transfers);
 
@@ -95,7 +96,8 @@ class PaymentSplitServiceTest extends KernelTestCase
             $this->miraklClient->listProductOrdersById([
                 MiraklMockedHttpClient::ORDER_STATUS_SHIPPING,
                 MiraklMockedHttpClient::ORDER_STATUS_REFUSED
-            ])
+            ]),
+            []
         );
         $this->assertCount(2, $transfers);
 
@@ -103,7 +105,8 @@ class PaymentSplitServiceTest extends KernelTestCase
             $this->miraklClient->listProductOrdersById([
                 MiraklMockedHttpClient::ORDER_STATUS_SHIPPING,
                 MiraklMockedHttpClient::ORDER_STATUS_RECEIVED
-            ])
+            ]),
+            []
         );
         // SHIPPING is already pending
         $this->assertCount(1, $transfers);
@@ -112,7 +115,8 @@ class PaymentSplitServiceTest extends KernelTestCase
             $this->miraklClient->listProductOrdersById([
                 MiraklMockedHttpClient::ORDER_STATUS_SHIPPING,
                 MiraklMockedHttpClient::ORDER_STATUS_RECEIVED
-            ])
+            ]),
+            []
         );
         // Both are already pending
         $this->assertCount(0, $transfers);
@@ -129,7 +133,7 @@ class PaymentSplitServiceTest extends KernelTestCase
             MiraklMockedHttpClient::ORDER_STATUS_REFUSED,
             MiraklMockedHttpClient::ORDER_STATUS_RECEIVED
         ]);
-        $transfers = $this->paymentSplitService->getTransfersFromOrders($orders);
+        $transfers = $this->paymentSplitService->getTransfersFromOrders($orders, []);
         $this->assertCount(4, $transfers);
 
         // Only STAGING and WAITING_DEBIT_PAYMENT are retriable
@@ -145,7 +149,7 @@ class PaymentSplitServiceTest extends KernelTestCase
         $order['order_lines'][0]['order_line_state'] = 'SHIPPING';
         $order['order_lines'][1]['order_line_state'] = 'SHIPPING';
         $orders[$id] = new MiraklProductOrder($order);
-        $transfers = $this->paymentSplitService->updateTransfersFromOrders($transfers, $orders);
+        $transfers = $this->paymentSplitService->updateTransfersFromOrders($transfers, $orders, []);
         $this->assertCount(2, $transfers);
 
         $transfers = $this->getTransfersFromRepository();


### PR DESCRIPTION
For service orders we need the information from SPA11 (pending debits). Right now the connector calls the endpoint once per order in the backlog. Since service order payment can take days the backlog can contain quite a few orders and get a 429 error from Mirakl (the limit is 120 calls per minute).

This fix calls SPA11 once per backlog chunk. It's not very pretty as we have to pass a list of pending debits to the location where it will be needed but I could not find a better way to achieve this.

Note the first commit where I changed the query serialization in order to handle alphanumerical order ids. From my tests it is backward compatible. I wanted to point it out since every call goes through this bit of code. Other than that this fix should have no impact, especially not for the product orders workflow.