### PR TITLE
Fix seller onboarding checkpoint

### DIFF
--- a/src/Command/SellerOnboardingCommand.php
+++ b/src/Command/SellerOnboardingCommand.php
@@ -88,9 +88,6 @@ class SellerOnboardingCommand extends Command implements LoggerAwareInterface
         foreach ($shops as $shopId => $shop) {
             $this->logger->debug("Processing Mirakl Shop: $shopId.");
 
-            // New checkpoint
-            $newCheckpoint = $shop->getLastUpdatedDate();
-
             // Retrieve AccountMappings and create missing Stripe Accounts in the process
             try {
                 $accountMapping = $this->sellerOnboardingService->getAccountMappingFromShop($shop);
@@ -127,6 +124,12 @@ class SellerOnboardingCommand extends Command implements LoggerAwareInterface
                 ]);
             }
         }
+
+        // Retrieve new checkpoint
+        uasort($shops, function ($s1, $s2) {
+            return strtotime($s2->getLastUpdatedDate()) - strtotime($s1->getLastUpdatedDate());
+        });
+        $newCheckpoint = current($shops)->getLastUpdatedDate();
 
         // Save new checkpoint
         if (isset($newCheckpoint) && $checkpoint !== $newCheckpoint) {

--- a/tests/Command/SellerOnboardingCommandTest.php
+++ b/tests/Command/SellerOnboardingCommandTest.php
@@ -149,4 +149,14 @@ class SellerOnboardingCommandTest extends KernelTestCase
         $this->assertCount(1, $this->getAccountMappingsFromRepository());
         $this->assertNull(current($this->getAccountMappingsFromRepository())->getOnboardingToken());
     }
+
+    public function testShopUpdateDateCheckpoint()
+    {
+        $this->deleteAllAccountMappingsFromRepository();
+        $this->mockAccountMapping(MiraklMock::SHOP_WITH_OAUTH_URL);
+        $this->mockAccountMapping(MiraklMock::SHOP_WITH_URL, StripeMock::ACCOUNT_PAYOUT_DISABLED);
+        $this->configService->setSellerOnboardingCheckpoint(MiraklMock::SHOP_DATE_MULTIPLE_UNSORTED);
+        $this->executeCommand();
+        $this->assertEquals(MiraklMock::SHOP_DATE_1_EXISTING_WITH_OAUTH_URL, $this->configService->getSellerOnboardingCheckpoint());
+    }
 }

--- a/tests/MiraklMockedHttpClient.php
+++ b/tests/MiraklMockedHttpClient.php
@@ -79,6 +79,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 	public const SHOP_DATE_1_EXISTING_WITHOUT_URL = '2019-01-04T00:00:00+0100';
 	public const SHOP_DATE_1_EXISTING_WITH_URL = '2019-01-05T00:00:00+0100';
 	public const SHOP_DATE_1_EXISTING_WITH_OAUTH_URL = '2019-01-06T00:00:00+0100';
+    public const SHOP_DATE_MULTIPLE_UNSORTED = '2019-01-07T00:00:00+0100';
 
 	public const INVOICE_BASIC = 1;
 	public const INVOICE_INVALID_AMOUNT = 2;
@@ -872,6 +873,9 @@ class MiraklMockedHttpClient extends MockHttpClient
 			case self::SHOP_DATE_1_EXISTING_WITH_OAUTH_URL:
 				$shops = $this->mockShopsById([self::SHOP_WITH_OAUTH_URL]);
 				break;
+            case self::SHOP_DATE_MULTIPLE_UNSORTED:
+                $shops = $this->mockShopsById([self::SHOP_WITH_OAUTH_URL, self::SHOP_WITH_URL]);
+                break;
 			default:
 				$shops = [];
 		}
@@ -896,6 +900,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 						'code' => $this->customFieldCode,
 						'value' => 'https://connect.stripe.com/setup/s/mov7fZc0o4Yx',
 					];
+                    $shop['last_updated_date'] = self::SHOP_DATE_1_EXISTING_WITH_URL;
 					$shops[] = $shop;
 					break;
 				case self::SHOP_WITH_OAUTH_URL:
@@ -903,6 +908,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 						'code' => $this->customFieldCode,
 						'value' => 'https://connect.stripe.com/express/oauth/authorize',
 					];
+                    $shop['last_updated_date'] = self::SHOP_DATE_1_EXISTING_WITH_OAUTH_URL;
 					$shops[] = $shop;
 					break;
 				case self::SHOP_INVALID:


### PR DESCRIPTION
Hi! There is an issue with the seller onboarding command since v3 (I think that is when the checkpoint was introduced). The S20 Mirakl endpoint (`GET /api/shops`) does not sort its results by date. Nor does it allow a sorting parameter to be passed.

I applied the same fix as previously done on orders. The shops are now sorted in-memory to be sure to put the checkpoint to the last updated timestamp.