### PR TITLE
Enable ignored Mirakl shops

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
   env(MAIL_ON_NOTIFICATION_ENDPOINT_DOWN_COOLDOWN): 10
   env(STRIPE_PREFILL_ONBOARDING): false
   env(MIRAKL_CUSTOM_FIELD_CODE): "stripe-url"
+  env(MIRAKL_IGNORED_SHOP_FIELD_CODE): "stripe-ignored"
   env(ENABLE_SERVICE_PAYMENT_SPLIT): false
   env(ENABLE_SERVICE_PAYMENT_REFUND): false
   env(ENABLE_SELLER_ONBOARDING): true
@@ -45,6 +46,7 @@ parameters:
   app.mirakl.api_key: "%env(MIRAKL_API_KEY)%"
   app.mirakl.host_name: "%env(MIRAKL_HOST_NAME)%"
   app.mirakl.stripe_custom_field_code: "%env(MIRAKL_CUSTOM_FIELD_CODE)%"
+  app.mirakl.stripe_ignored_shop_field_code: "%env(MIRAKL_IGNORED_SHOP_FIELD_CODE)%"
   app.redirect.onboarding: "%env(default:default_redirect_onboarding:REDIRECT_ONBOARDING)%"
   app.operator.notification_url: "%env(OPERATOR_NOTIFICATION_URL)%"
   app.mailer.technical: "%env(TECHNICAL_ALERT_EMAIL)%"
@@ -66,6 +68,7 @@ services:
       $miraklApiKey: "%app.mirakl.api_key%"
       $miraklHostName: "%app.mirakl.host_name%"
       $customFieldCode: "%app.mirakl.stripe_custom_field_code%"
+      $ignoredShopFieldCode: "%app.mirakl.stripe_ignored_shop_field_code%"
       $enableProductPaymentSplit: "%app.workflow.enable_product_payment_split%"
       $enableServicePaymentSplit: "%app.workflow.enable_service_payment_split%"
       $enableProductPaymentRefund: "%app.workflow.enable_product_payment_refund%"

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -17,6 +17,7 @@ services:
     public: true
     bind:
       $customFieldCode: "%app.mirakl.stripe_custom_field_code%"
+      $ignoredShopFieldCode: "%app.mirakl.stripe_ignored_shop_field_code%"
 
   App\Service\MiraklClient:
     class: App\Service\MiraklClient

--- a/src/Command/SellerOnboardingCommand.php
+++ b/src/Command/SellerOnboardingCommand.php
@@ -99,6 +99,12 @@ class SellerOnboardingCommand extends Command implements LoggerAwareInterface
                 continue;
             }
 
+            $ignoredShop = $this->sellerOnboardingService->isShopIgnored($shop);
+            if ($accountMapping->getIgnored() !== $ignoredShop) {
+                $this->logger->info("Shop $shopId is now ignored=$ignoredShop");
+                $this->sellerOnboardingService->updateAccountMappingIgnored($accountMapping, $ignoredShop);
+            }
+
             try {
                 // Ignore if custom field already has a value other than the oauth URL (for backward compatibility)
                 $customFieldValue = $this->sellerOnboardingService->getCustomFieldValue($shop);

--- a/src/Command/SellerOnboardingCommand.php
+++ b/src/Command/SellerOnboardingCommand.php
@@ -101,7 +101,7 @@ class SellerOnboardingCommand extends Command implements LoggerAwareInterface
 
             $ignoredShop = $this->sellerOnboardingService->isShopIgnored($shop);
             if ($accountMapping->getIgnored() !== $ignoredShop) {
-                $this->logger->info("Shop $shopId is now ignored=$ignoredShop");
+                $this->logger->info("Shop $shopId is now ignored=" . var_export($ignoredShop, true));
                 $this->sellerOnboardingService->updateAccountMappingIgnored($accountMapping, $ignoredShop);
             }
 

--- a/src/Entity/AccountMapping.php
+++ b/src/Entity/AccountMapping.php
@@ -53,6 +53,11 @@ class AccountMapping
     private $payinEnabled = false;
 
     /**
+     * @ORM\Column(type="boolean", options={"default" : false})
+     */
+    private $ignored = false;
+
+    /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
     private $disabledReason;
@@ -130,6 +135,18 @@ class AccountMapping
     public function setPayinEnabled(bool $payinEnabled): self
     {
         $this->payinEnabled = $payinEnabled;
+
+        return $this;
+    }
+
+    public function getIgnored(): ?bool
+    {
+        return $this->ignored;
+    }
+
+    public function setIgnored(bool $ignored): self
+    {
+        $this->ignored = $ignored;
 
         return $this;
     }

--- a/src/Entity/StripeTransfer.php
+++ b/src/Entity/StripeTransfer.php
@@ -36,6 +36,7 @@ class StripeTransfer
     public const TRANSFER_PENDING = 'TRANSFER_PENDING';
     public const TRANSFER_FAILED = 'TRANSFER_FAILED';
     public const TRANSFER_CREATED = 'TRANSFER_CREATED';
+    public const TRANSFER_IGNORED = 'TRANSFER_IGNORED';
 
     // Transfer status reasons: on hold
     public const TRANSFER_STATUS_REASON_SHOP_NOT_READY = 'Cannot find Stripe account for shop ID %s';
@@ -139,6 +140,7 @@ class StripeTransfer
             self::TRANSFER_FAILED,
             self::TRANSFER_ON_HOLD,
             self::TRANSFER_ABORTED,
+            self::TRANSFER_IGNORED,
         ];
     }
 

--- a/src/Migrations/Version20221031140741.php
+++ b/src/Migrations/Version20221031140741.php
@@ -9,19 +9,19 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20221031140741 extends AbstractMigration
 {
-    public function getDescription() : string
+    public function getDescription(): string
     {
         return 'Add AccountMapping ignored field';
     }
 
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 
         $this->addSql('ALTER TABLE account_mapping ADD ignored BOOLEAN DEFAULT \'false\' NOT NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
 

--- a/src/Migrations/Version20221031140741.php
+++ b/src/Migrations/Version20221031140741.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20221031140741 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return 'Add AccountMapping ignored field';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE account_mapping ADD ignored BOOLEAN DEFAULT \'false\' NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE account_mapping DROP ignored');
+    }
+}

--- a/src/Service/SellerOnboardingService.php
+++ b/src/Service/SellerOnboardingService.php
@@ -48,6 +48,11 @@ class SellerOnboardingService
      */
     private $customFieldCode;
 
+    /**
+     * @var string
+     */
+    private $ignoredShopFieldCode;
+
     public function __construct(
         AccountMappingRepository $accountMappingRepository,
         MiraklClient $miraklClient,
@@ -55,7 +60,8 @@ class SellerOnboardingService
         RouterInterface $router,
         string $redirectOnboarding,
         bool $stripePrefillOnboarding,
-        string $customFieldCode
+        string $customFieldCode,
+        string $ignoredShopFieldCode
     ) {
         $this->accountMappingRepository = $accountMappingRepository;
         $this->miraklClient = $miraklClient;
@@ -64,6 +70,7 @@ class SellerOnboardingService
         $this->redirectOnboarding = $redirectOnboarding;
         $this->stripePrefillOnboarding = $stripePrefillOnboarding;
         $this->customFieldCode = $customFieldCode;
+        $this->ignoredShopFieldCode = $ignoredShopFieldCode;
     }
 
     /**
@@ -90,6 +97,16 @@ class SellerOnboardingService
         }
 
         return $accountMapping;
+    }
+
+    /**
+     * @param AccountMapping $accountMapping
+     * @param bool $ignored
+     */
+    public function updateAccountMappingIgnored(AccountMapping $accountMapping, bool $ignored): void
+    {
+        $accountMapping->setIgnored($ignored);
+        $this->accountMappingRepository->persistAndFlush($accountMapping);
     }
 
     /**
@@ -123,6 +140,15 @@ class SellerOnboardingService
     public function getCustomFieldValue(MiraklShop $shop): ?string
     {
         return $shop->getCustomFieldValue($this->customFieldCode);
+    }
+
+    /**
+     * @param MiraklShop $shop
+     * @return bool True if the field is set and the shop ignored, false otherwise.
+     */
+    public function isShopIgnored(MiraklShop $shop): bool
+    {
+        return $shop->getCustomFieldValue($this->ignoredShopFieldCode) === "true";
     }
 
     /**

--- a/tests/Command/SellerOnboardingCommandTest.php
+++ b/tests/Command/SellerOnboardingCommandTest.php
@@ -159,4 +159,24 @@ class SellerOnboardingCommandTest extends KernelTestCase
         $this->executeCommand();
         $this->assertEquals(MiraklMock::SHOP_DATE_1_EXISTING_WITH_OAUTH_URL, $this->configService->getSellerOnboardingCheckpoint());
     }
+
+    public function testIgnoredNewShop()
+    {
+        $this->deleteAllAccountMappingsFromRepository();
+//        $this->mockAccountMapping(MiraklMock::SH, StripeMock::ACCOUNT_BASIC, false, false, null, true);
+        $this->configService->setSellerOnboardingCheckpoint(MiraklMock::SHOP_DATE_1_NEW_IGNORED);
+        $this->executeCommand();
+        $this->assertCount(1, $this->getAccountMappingsFromRepository());
+        $this->assertEquals(true, current($this->getAccountMappingsFromRepository())->getIgnored());
+    }
+
+    public function testIgnoredExistingShop()
+    {
+        $this->deleteAllAccountMappingsFromRepository();
+        $this->mockAccountMapping(MiraklMock::SHOP_EXISTING_IGNORED);
+        $this->configService->setSellerOnboardingCheckpoint(MiraklMock::SHOP_DATE_1_EXISTING_IGNORED);
+        $this->executeCommand();
+        $this->assertCount(1, $this->getAccountMappingsFromRepository());
+        $this->assertEquals(true, current($this->getAccountMappingsFromRepository())->getIgnored());
+    }
 }

--- a/tests/Command/SellerOnboardingCommandTest.php
+++ b/tests/Command/SellerOnboardingCommandTest.php
@@ -163,7 +163,6 @@ class SellerOnboardingCommandTest extends KernelTestCase
     public function testIgnoredNewShop()
     {
         $this->deleteAllAccountMappingsFromRepository();
-//        $this->mockAccountMapping(MiraklMock::SH, StripeMock::ACCOUNT_BASIC, false, false, null, true);
         $this->configService->setSellerOnboardingCheckpoint(MiraklMock::SHOP_DATE_1_NEW_IGNORED);
         $this->executeCommand();
         $this->assertCount(1, $this->getAccountMappingsFromRepository());


### PR DESCRIPTION
This PR adds the option to ignore Mirakl shops. This can be needed when some shops should not have their payments handled by Stripe. Right now the connector will try any shop, and since v3 even if a shop is not completely onboarded it will try to create its transfers in Stripe each time the job runs.

The feature is implemented using a custom boolean field in Mirakl. When the shop is ignored, its transactions are set to a new "ignored" status in order not to interfere with existing workflows. If the shop does not have the field set, it is not ignored, meaning the feature is opt-in. No additional configuration is needed when upgrading the connector if you do not want to use it.