### PR TITLE
Handling refund timeouts for Mirakl

### DIFF
--- a/src/Handler/ProcessRefundHandler.php
+++ b/src/Handler/ProcessRefundHandler.php
@@ -104,7 +104,10 @@ class ProcessRefundHandler implements MessageHandlerInterface, LoggerAwareInterf
                     'miraklOrderId' => $refund->getMiraklOrderId()
                 ]
             );
-        catch (ClientException $e) {
+			
+		    $refund->setStatus(StripeRefund::REFUND_FAILED);
+            $refund->setStatusReason(substr($e->getMessage(), 0, 1024));
+        } catch (ClientException $e) {
             $message = $e->getResponse()->getContent(false);
             $this->logger->error(
                 sprintf('Could not validate refund in Mirakl: %s.', $message),

--- a/tests/Handler/ProcessRefundHandlerTest.php
+++ b/tests/Handler/ProcessRefundHandlerTest.php
@@ -168,7 +168,24 @@ class ProcessRefundHandlerTest extends KernelTestCase
             ]
         ));
     }
+	
+	public function testProductRefundWithMiraklTimeout()
+    {
+        $refund = $this->mockRefund(
+            StripeRefund::REFUND_PRODUCT_ORDER,
+            MiraklMock::PRODUCT_ORDER_REFUND_TIMEOUT,
+            StripeMock::CHARGE_BASIC
+        );
+        $this->executeHandler($refund->getId());
 
+        $refund = $this->stripeRefundRepository->findOneBy([
+            'id' => $refund->getId()
+        ]);
+
+        $this->assertEquals(StripeRefund::REFUND_FAILED, $refund->getStatus());
+        $this->assertEquals(StripeMock::REFUND_BASIC, $refund->getStripeRefundId());
+    }
+	
     public function testValidServiceRefund()
     {
         $refund = $this->mockRefund(

--- a/tests/MiraklMockedHttpClient.php
+++ b/tests/MiraklMockedHttpClient.php
@@ -7,6 +7,7 @@ use App\Service\MiraklClient;
 use App\Tests\StripeMockedHttpClient as StripeMock;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpClient\Exception\TransportException;
 
 class MiraklMockedHttpClient extends MockHttpClient
 {
@@ -61,6 +62,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 	public const SERVICE_ORDER_PENDING_REFUND = 'service_order_pending_refund';
 	public const PRODUCT_ORDER_REFUND_BASIC = 1000;
 	public const PRODUCT_ORDER_REFUND_VALIDATED = 1001;
+	public const PRODUCT_ORDER_REFUND_TIMEOUT = 1002;
 	public const SERVICE_ORDER_REFUND_BASIC = 2000;
 	public const SERVICE_ORDER_REFUND_VALIDATED = 2001;
 
@@ -142,6 +144,8 @@ class MiraklMockedHttpClient extends MockHttpClient
 				}
 			} catch (InvalidArgumentException $e) {
 				throw new \Exception("Unpexpected URL: {$url}. Method: {$method}.");
+			 } catch (TransportException $e) {
+				throw new TransportException($e->getMessage());
 			} catch (\Exception $e) {
 				return new MockResponse(
 					['message' => $e->getMessage()],
@@ -813,6 +817,8 @@ class MiraklMockedHttpClient extends MockHttpClient
 			case self::PRODUCT_ORDER_REFUND_VALIDATED:
 			case self::SERVICE_ORDER_REFUND_VALIDATED:
 				throw new \Exception("$id already validated", 400);
+			case self::PRODUCT_ORDER_REFUND_TIMEOUT:
+				throw new TransportException("Call to Mirakl Timed out"); 
 		}
 	}
 


### PR DESCRIPTION
This fixes an issue we have seen where the refund handler is correctly sending the refund in stripe and then timing out when contacting Mirakl. This leaves the refund in a pending status.

The fix is to catch TransportException which occurs when the Symfony HTTPClient times out. This results in the handler retrying the connection to Mirakl and hence reduces the errors. If there is an actual timeout then we properly capture it in the logs and don't leave the Stripe_Refund table in an intermediate state.
https://github.com/symfony/symfony/tree/6.3/src/Symfony/Component/HttpClient

Might also be good to introduce a configurable timeout in src\Service\MiraklClient.php, we increased the timeout from 60s to 90s but I've not included that in this PR.