### PR TITLE
fix(config): update nelmio config for v4

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -5,12 +5,13 @@ nelmio_api_doc:
             description: >
                 This connector allows marketplaces powered by Mirakl to onboard sellers on Stripe and pay them out automatically.
             version: 3.1.11
-        securityDefinitions:
-            Bearer:
-                type: apiKey
-                description: 'Token configured by the operator during the installation'
-                name: X-AUTH-TOKEN
-                in: header
+        components:
+            securitySchemes:
+                Bearer:
+                    type: apiKey
+                    description: 'Token configured by the operator during the installation'
+                    name: X-AUTH-TOKEN
+                    in: header
 
     areas: # to filter documented areas
         path_patterns:


### PR DESCRIPTION
The NelmioApiDocBundle update from v3 to v4 in https://github.com/stripe/stripe-mirakl-connector/releases/tag/v3.0.3 updated its version of SwaggerPHP with accompanying BC breaks:
- https://github.com/nelmio/NelmioApiDocBundle/blob/master/UPGRADE-4.0.md
- https://github.com/zircote/swagger-php/blob/3.x/docs/Migrating-to-v3.md

The visible breakage we saw was some log output telling us that these security annotations were no longer correct.