### PR TITLE
Fix tax split enabling

### DIFF
--- a/src/Factory/StripeTransferFactory.php
+++ b/src/Factory/StripeTransferFactory.php
@@ -307,17 +307,18 @@ class StripeTransferFactory implements LoggerAwareInterface
             }
 
             // Amount and currency
-            $transferAmount = $refund->getAmount();
             $commission = $order->getRefundedOperatorCommission($refund);
             $commission = gmp_intval((string) ($commission * 100));
-            $refundedTax = $order->getRefundedTax($refund);
-            $refundedTax = gmp_intval((string) ($refundedTax * 100));
-            $transferAmount = $transferAmount - $commission - $refundedTax;
-
-            if ($isForTax) {
-                $transferAmount = $refundedTax;
+            $transferAmount = $refund->getAmount() - $commission;
+            if ($this->enablePaymentTaxSplit) {
+                $refundedTax = $order->getRefundedTax($refund);
+                $refundedTax = gmp_intval((string) ($refundedTax * 100));
+                if ($isForTax) {
+                    $transferAmount = $refundedTax;
+                } else {
+                    $transferAmount = $transferAmount - $refundedTax;
+                }
             }
-
             $transfer->setAmount($transferAmount);
             $transfer->setCurrency(strtolower($order->getCurrency()));
         } catch (InvalidArgumentException $e) {

--- a/tests/Service/PaymentSplitServiceTest.php
+++ b/tests/Service/PaymentSplitServiceTest.php
@@ -53,7 +53,8 @@ class PaymentSplitServiceTest extends KernelTestCase
             $this->miraklClient,
             $container->get('App\Service\StripeClient'),
             'acc_xxxxxxx',
-            '_TAX'
+            '_TAX',
+            false
         );
         $stripeTransferFactory->setLogger(new NullLogger());
 

--- a/tests/Service/SellerSettlementServiceTest.php
+++ b/tests/Service/SellerSettlementServiceTest.php
@@ -61,7 +61,8 @@ class SellerSettlementServiceTest extends KernelTestCase
             $this->miraklClient,
             $container->get('App\Service\StripeClient'),
             'acc_xxxxxxx',
-            '_TAX'
+            '_TAX',
+            false
         );
         $stripeTransferFactory->setLogger(new NullLogger());
 


### PR DESCRIPTION
The feature from #116 introduces regressions when it is not activated (so the default behavior of the connector):

1. The amounts of transfers and refunds are not guarded by a feature flag so tax amount is subtracted from the transaction amount. It should be done only if the feature is activated because taxes will be handled by a separate transaction. This is critical as the connector transfers wrong amounts by default.
2. A reverse transaction is created for refund taxes even when the feature is disabled. This creates transaction lines in the database that will never complete. This is more of a performance issue since it could bloat the database.

I also reworked the unit tests so that amounts are validated with and without the feature enabled.