### PR TITLE
Additional Account Metadata Field

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -149,3 +149,7 @@ MAILER_DSN=smtp://null
 # Tax split configuration for new product order & backlog product order, for new service order & backlog service order
 #ENABLE_PAYMENT_TAX_SPLIT=false
 #STRIPE_TAX_ACCOUNT=acct_xxxxxx
+
+# Define the additional metadata sent to Stripe account on create/update
+# Default to {"operator_internal_id": "operatorInternalId"}, can be used to add custom metadata to the Stripe account (multiple fields can be separated by comma)
+#STRIPE_ACCOUNT_METADATA={"operator_internal_id": "operatorInternalId"}

--- a/.env.dist
+++ b/.env.dist
@@ -152,4 +152,4 @@ MAILER_DSN=smtp://null
 
 # Define the additional metadata sent to Stripe account on create/update
 # Default to {"operator_internal_id": "operatorInternalId"}, can be used to add custom metadata to the Stripe account (multiple fields can be separated by comma)
-#STRIPE_ACCOUNT_METADATA={"operator_internal_id": "operatorInternalId"}
+STRIPE_ACCOUNT_METADATA={"operator_internal_id": "operatorInternalId"}

--- a/src/Service/SellerOnboardingService.php
+++ b/src/Service/SellerOnboardingService.php
@@ -93,6 +93,11 @@ class SellerOnboardingService
             }
             $accountMapping->setPayinEnabled((bool) $stripeAccount->charges_enabled);
             $this->accountMappingRepository->persistAndFlush($accountMapping);
+        } else {
+            $stripeAccount = $this->stripeClient->retrieveAccount($accountMapping->getStripeAccountId());
+            if ($stripeAccount && $stripeAccount->id) {
+                $this->updateStripeAccountFromShop($shop, $stripeAccount);
+            }
         }
 
         return $accountMapping;
@@ -102,6 +107,12 @@ class SellerOnboardingService
     {
         $accountMapping->setIgnored($ignored);
         $this->accountMappingRepository->persistAndFlush($accountMapping);
+    }
+
+    protected function updateStripeAccountFromShop(MiraklShop $shop, Account $stripeAccount)
+    {
+        $additionalMetaDataFields = $this->getAdditionalMetaDataFields($shop);
+        $this->stripeClient->updateStripeAccount($stripeAccount->id, [], $additionalMetaDataFields);
     }
 
     /**
@@ -123,7 +134,34 @@ class SellerOnboardingService
             ];
         }
 
-        return $this->stripeClient->createStripeAccount($shop->getId(), $details, ['miraklShopId' => $shop->getId()]);
+        $additionalMetaDataFields = $this->getAdditionalMetaDataFields($shop);
+
+        $metaData = array_merge($additionalMetaDataFields, [
+            'miraklShopId' => $shop->getId()
+        ]);
+
+        return $this->stripeClient->createStripeAccount($shop->getId(), $details, $metaData);
+    }
+
+    /**
+     * @param $shop
+     * @return array
+     */
+    private function getAdditionalMetaDataFields($shop)
+    {
+        $additionalMetaDataFields = [];
+        if (getenv('STRIPE_ACCOUNT_METADATA') !== null) {
+            $shopData = $shop->getShop();
+            $additionalMetaData = json_decode(getenv('STRIPE_ACCOUNT_METADATA'));
+
+            foreach ($additionalMetaData as $fieldKey => $fieldValue) {
+                if (isset($shopData[$fieldKey])) {
+                    $additionalMetaDataFields[$fieldValue] = $shopData[$fieldKey];
+                }
+            }
+        }
+
+        return $additionalMetaDataFields;
     }
 
     /**

--- a/src/Service/StripeClient.php
+++ b/src/Service/StripeClient.php
@@ -56,7 +56,7 @@ class StripeClient
     {
         return [
             'pluginName' => self::APP_NAME,
-            'pluginVersion' => $this->version,
+            'pluginVersion' => $this->version
         ];
     }
 
@@ -96,6 +96,13 @@ class StripeClient
                 'schedule' => ['interval' => 'manual'],
             ]],
             'metadata' => array_merge($metadata, $this->getDefaultMetadata()),
+        ], $details));
+    }
+
+    public function updateStripeAccount(string $stripeAccountId, array $details, array $metaData = []): Account
+    {
+        return Account::update($stripeAccountId, array_merge([
+            'metadata' => array_merge($metaData, $this->getDefaultMetadata())
         ], $details));
     }
 


### PR DESCRIPTION
For adding new fields on the account metadata sync between Mirakl and Stripe, customize the .env file by altering the line STRIPE_ACCOUNT_METADATA according to the details from the .env.dist file. By default, the value is set to JSON {"operator_internal_id": "operatorInternalId"} where the key represents the field from Mirakl and the value represents the metadata field key set in Stripe.