### PR TITLE
Fix HEADER_X_FORWARDED_ALL removed in Symfony 6

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -13,7 +13,10 @@ if ($_SERVER['APP_DEBUG']) {
 }
 
 if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_ALL ^ Request::HEADER_X_FORWARDED_HOST);
+    Request::setTrustedProxies(
+        explode(',', $trustedProxies),
+        Request::HEADER_X_FORWARDED_FOR | Request::HEADER_X_FORWARDED_PORT | Request::HEADER_X_FORWARDED_PROTO
+    );
 }
 
 if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {


### PR DESCRIPTION
## Summary

`public/index.php` uses `Request::HEADER_X_FORWARDED_ALL`, which was [deprecated in `symfony/http-foundation` 5.2 and removed in 6.0](https://github.com/symfony/symfony/blob/6.0/UPGRADE-6.0.md#httpfoundation). Since this project's `composer.json` pins `symfony/*` to `6.4.*`, any request that enters the trusted-proxies branch crashes with:

```
PHP Fatal error: Uncaught Error: Undefined constant Symfony\Component\HttpFoundation\Request::HEADER_X_FORWARDED_ALL in /var/www/html/public/index.php:16
```

PHP only resolves class constants at runtime, which is why this slips through `composer install` and `bin/console cache:warmup` and only fires on the **first HTTP request** that has `TRUSTED_PROXIES` set — i.e. every deployment behind a load balancer / reverse proxy / Kubernetes ingress.

The bug has been present since the Symfony 6.4 upgrade (commit `aab24bb` and friends) and is reproducible on tags `v4.1`, `v4.1.1` and current `master`.

## Reproduction

1. `composer install` on `master` (PHP 8.4, Symfony 6.4.x).
2. Run the app via `php-fpm` / `symfony serve` with `TRUSTED_PROXIES=10.0.0.0/8` (or any non-empty value) in the environment.
3. Issue any HTTP request → HTTP 500, fatal error above.

If `TRUSTED_PROXIES` is unset the bug is silently dormant, which is why local dev usually doesn't hit it.

## Fix

Replace the removed constant with its explicit bitmask. The original expression was:

```
HEADER_X_FORWARDED_ALL ^ HEADER_X_FORWARDED_HOST
  = (FOR | HOST | PORT | PROTO) ^ HOST
  = FOR | PORT | PROTO
```

so the patched line trusts exactly the same headers as before (`X-Forwarded-For`, `X-Forwarded-Port`, `X-Forwarded-Proto`) and keeps ignoring `X-Forwarded-Host` — preserving the original defence-in-depth posture against Host header spoofing (`TRUSTED_HOSTS` remains the source of truth for the host).

Diff is a single-line behavioural no-op modulo the removed constant; `php -l public/index.php` passes.

## Test plan

- [x] `php -l public/index.php` → no syntax errors.
- [x] Bitmask arithmetic verified against Symfony 5.x source (`HEADER_X_FORWARDED_ALL = 0b11110`, `HEADER_X_FORWARDED_HOST = 0b00100`, XOR = `0b11010` = `FOR | PORT | PROTO`).
- [x] Manual run with `TRUSTED_PROXIES` set on Symfony 6.4.x — no more fatal, `Request::getClientIp()` / `Request::isSecure()` return the proxied values as expected.