### PR TITLE
Add security check to verify Stripe account = order's shop owner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 4.1.2
+- Added security check to verify Stripe account matches order's shop mapping before updating payment mappings
+
 ## Version 4.1.1
 - Fix: handle `payout.failed` webhook event to correctly update connector payout status when Stripe reports a failure, preventing stale `PAYOUT_CREATED` states and enabling proper retries and downstream notifications.
 

--- a/src/Controller/StripeWebhookEndpoint.php
+++ b/src/Controller/StripeWebhookEndpoint.php
@@ -8,6 +8,7 @@ use App\Message\AccountUpdateMessage;
 use App\Repository\AccountMappingRepository;
 use App\Repository\PaymentMappingRepository;
 use App\Repository\StripePayoutRepository;
+use App\Service\MiraklClient;
 use App\Service\StripeClient;
 use OpenApi\Attributes as OA;
 use Psr\Log\LoggerAwareInterface;
@@ -76,17 +77,24 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
      */
     private $metadataCommercialOrderId;
 
+    /**
+     * @var MiraklClient
+     */
+    private $miraklClient;
+
     public function __construct(
         MessageBusInterface $bus,
         StripeClient $stripeClient,
         AccountMappingRepository $accountMappingRepository,
         PaymentMappingRepository $paymentMappingRepository,
         StripePayoutRepository $stripePayoutRepository,
+        MiraklClient $miraklClient,
         string $webhookSellerSecret,
         string $webhookOperatorSecret,
         string $metadataCommercialOrderId
     ) {
         $this->bus = $bus;
+        $this->miraklClient = $miraklClient;
         $this->stripeClient = $stripeClient;
         $this->accountMappingRepository = $accountMappingRepository;
         $this->paymentMappingRepository = $paymentMappingRepository;
@@ -188,7 +196,7 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
         }
 
         if (!in_array($event['type'], self::HANDLED_EVENT_TYPES)) {
-            $this->logger->error(sprintf('Unhandled event type %s.', (bool) $event['type']));
+            $this->logger->error(sprintf('Unhandled event type %s.', (string) $event['type']));
 
             return new Response('Unhandled event type', Response::HTTP_BAD_REQUEST);
         }
@@ -257,11 +265,36 @@ class StripeWebhookEndpoint extends AbstractController implements LoggerAwareInt
         $charge = $event->data->object;
         assert($charge instanceof \Stripe\Charge);
 
-
+        $stripeAccount = $event->account ?? null;
 
         $miraklCommercialOrderId = $this->findMiraklCommercialOrderId($charge);
         if (!$miraklCommercialOrderId) {
+            $this->logger->info(sprintf('Ignoring event with no Mirakl Commercial Order ID for Stripe charge: %s', $charge->id));
             return 'Ignoring event with no Mirakl Commercial Order ID.';
+        }
+
+        if (!empty($stripeAccount)) {
+            $orderList = $this->miraklClient->listProductOrdersByCommercialId([$miraklCommercialOrderId]);
+            if (empty($orderList)) {
+                $orderList = $this->miraklClient->listServiceOrdersByCommercialId([$miraklCommercialOrderId]);
+            }
+            if (empty($orderList)) {
+                $this->logger->info(sprintf('Ignoring event with no Mirakl Order for Stripe charge: %s', $charge->id));
+                return 'Ignoring event with no Mirakl Order.';
+            }
+            $shopId = current(current($orderList))->getShopId();
+
+            $accountMapping = $this->accountMappingRepository->findByMiraklShopIds([$shopId]);
+            if (empty($accountMapping)) {
+                $this->logger->info(sprintf('Ignoring event for unknown Mirakl shop for Stripe charge: %s', $charge->id));
+                return 'Ignoring event for unknown Mirakl shop.';
+            }
+            $accountMapping = current($accountMapping);
+
+            if ($stripeAccount !== $accountMapping->getStripeAccountId()) {
+                $this->logger->info(sprintf('Ignoring event for unknown Stripe account for Stripe charge: %s', $charge->id));
+                return 'Ignoring event for unknown Stripe account.';
+            }
         }
 
         $paymentMapping = $this->paymentMappingRepository->findOneByStripeChargeId($charge->id);

--- a/tests/Controller/StripeWebhookEndpointTest.php
+++ b/tests/Controller/StripeWebhookEndpointTest.php
@@ -653,6 +653,124 @@ class StripeWebhookEndpointTest extends WebTestCase
         $this->assertEquals('unknown_code: Unknown failure reason', $updatedPayout->getStatusReason());
     }
 
+    public function testChargeUpdatedWithStripeAccountMatchingOrder()
+    {
+        $chargeId = StripeMock::CHARGE_BASIC;
+        $orderId = MiraklMock::ORDER_COMMERCIAL_ALL_VALIDATED;
+        $stripeAccountId = StripeMock::ACCOUNT_BASIC;
+
+        $response = $this->executeSellersRequest(<<<PAYLOAD
+        {
+            "type": "charge.updated",
+            "account": "$stripeAccountId",
+            "data": {
+                "object": {
+                    "id": "$chargeId",
+                    "object": "charge",
+                    "metadata": {"$this->paymentKey": "$orderId"},
+                    "status": "succeeded",
+                    "captured": false,
+                    "amount": 100
+                }
+            }
+        }
+        PAYLOAD);
+        $this->assertEquals('Payment mapping created.', $response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $paymentMapping = $this->paymentMappingRepository->findOneByStripeChargeId($chargeId);
+        $this->assertNotNull($paymentMapping);
+        $this->assertEquals($orderId, $paymentMapping->getMiraklCommercialOrderId());
+        $this->assertEquals(PaymentMapping::TO_CAPTURE, $paymentMapping->getStatus());
+    }
+
+    public function testChargeUpdatedWithStripeAccountMismatch()
+    {
+        $chargeId = StripeMock::CHARGE_BASIC;
+        $orderId = MiraklMock::ORDER_COMMERCIAL_ALL_VALIDATED;
+        $stripeAccountId = StripeMock::ACCOUNT_NEW;
+
+        $response = $this->executeSellersRequest(<<<PAYLOAD
+        {
+            "type": "charge.updated",
+            "account": "$stripeAccountId",
+            "data": {
+                "object": {
+                    "id": "$chargeId",
+                    "object": "charge",
+                    "metadata": {"$this->paymentKey": "$orderId"},
+                    "status": "succeeded",
+                    "captured": false,
+                    "amount": 100
+                }
+            }
+        }
+        PAYLOAD);
+        $this->assertEquals('Ignoring event for unknown Stripe account.', $response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $paymentMapping = $this->paymentMappingRepository->findOneByStripeChargeId($chargeId);
+        $this->assertNull($paymentMapping);
+    }
+
+    public function testChargeUpdatedWithStripeAccountNoMiraklOrder()
+    {
+        $chargeId = StripeMock::CHARGE_BASIC;
+        $orderId = MiraklMock::ORDER_COMMERCIAL_NOT_FOUND;
+        $stripeAccountId = StripeMock::ACCOUNT_BASIC;
+
+        $response = $this->executeSellersRequest(<<<PAYLOAD
+        {
+            "type": "charge.updated",
+            "account": "$stripeAccountId",
+            "data": {
+                "object": {
+                    "id": "$chargeId",
+                    "object": "charge",
+                    "metadata": {"$this->paymentKey": "$orderId"},
+                    "status": "succeeded",
+                    "captured": false,
+                    "amount": 100
+                }
+            }
+        }
+        PAYLOAD);
+        $this->assertEquals('Ignoring event with no Mirakl Order.', $response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $paymentMapping = $this->paymentMappingRepository->findOneByStripeChargeId($chargeId);
+        $this->assertNull($paymentMapping);
+    }
+
+    public function testChargeUpdatedWithStripeAccountUnknownMiraklShop()
+    {
+        $chargeId = StripeMock::CHARGE_BASIC;
+        $orderId = MiraklMock::ORDER_COMMERCIAL_INVALID_SHOP;
+        $stripeAccountId = StripeMock::ACCOUNT_BASIC;
+
+        $response = $this->executeSellersRequest(<<<PAYLOAD
+        {
+            "type": "charge.updated",
+            "account": "$stripeAccountId",
+            "data": {
+                "object": {
+                    "id": "$chargeId",
+                    "object": "charge",
+                    "metadata": {"$this->paymentKey": "$orderId"},
+                    "status": "succeeded",
+                    "captured": false,
+                    "amount": 100
+                }
+            }
+        }
+        PAYLOAD);
+        $this->assertEquals('Ignoring event for unknown Mirakl shop.', $response->getContent());
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+
+        $paymentMapping = $this->paymentMappingRepository->findOneByStripeChargeId($chargeId);
+        $this->assertNull($paymentMapping);
+    }
+
     public function testChargeUpdatedMetadataInExpandedPaymentIntentIsEmpty()
     {
         $chargeId = StripeMock::CHARGE_BASIC;

--- a/tests/MiraklMockedHttpClient.php
+++ b/tests/MiraklMockedHttpClient.php
@@ -57,6 +57,7 @@ class MiraklMockedHttpClient extends MockHttpClient
 	public const ORDER_COMMERCIAL_PARTIALLY_REFUSED = 'order_commercial_partially_refused';
 	public const ORDER_COMMERCIAL_CANCELED = 'order_commercial_canceled';
 	public const ORDER_COMMERCIAL_NOT_FOUND = 'order_commercial_not_found';
+	public const ORDER_COMMERCIAL_INVALID_SHOP = 'order_commercial_invalid_shop';
 
 	public const PRODUCT_ORDER_PENDING_REFUND = 'product_order_pending_refund';
 	public const SERVICE_ORDER_PENDING_REFUND = 'service_order_pending_refund';
@@ -420,6 +421,11 @@ class MiraklMockedHttpClient extends MockHttpClient
 				case self::ORDER_COMMERCIAL_CANCELED:
 					$orders = array_merge($orders, $this->mockOrdersById($isService, [
 						self::ORDER_STATUS_CANCELED
+					]));
+					break;
+				case self::ORDER_COMMERCIAL_INVALID_SHOP:
+					$orders = array_merge($orders, $this->mockOrdersById($isService, [
+						self::ORDER_INVALID_SHOP
 					]));
 					break;
 				case self::ORDER_COMMERCIAL_NOT_FOUND:


### PR DESCRIPTION
## Summary

Validate Stripe account ownership when processing charge webhooks to prevent unauthorized order updates.

## Changes

### Security Fix
- Added Stripe account ownership verification in [handleChargeEvent()](cci:1://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/src/Controller/StripeWebhookEndpoint.php:258:4-324:5) (lines 278-299)
- When a webhook event includes an `account` field (seller/connected-account events), the controller now:
  1. Resolves the Mirakl shop for the claimed commercial order ID
  2. Looks up that shop's Stripe account mapping
  3. Rejects the event if `event->account` ≠ the mapped Stripe account ID
- This prevents a compromised seller Stripe account from sending a webhook claiming ownership of another shop's order

### Test Coverage
- Added 4 new test cases in [StripeWebhookEndpointTest](cci:2://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/Controller/StripeWebhookEndpointTest.php:18:0-803:1):
  - [testChargeUpdatedWithStripeAccountMatchingOrder](cci:1://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/Controller/StripeWebhookEndpointTest.php:655:4-684:5) — valid matching account → payment mapping created
  - [testChargeUpdatedWithStripeAccountMismatch](cci:1://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/Controller/StripeWebhookEndpointTest.php:686:4-713:5) — Stripe account mismatch → event ignored
  - [testChargeUpdatedWithStripeAccountNoMiraklOrder](cci:1://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/Controller/StripeWebhookEndpointTest.php:715:4-742:5) — no Mirakl order found → event ignored
  - [testChargeUpdatedWithStripeAccountUnknownMiraklShop](cci:1://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/Controller/StripeWebhookEndpointTest.php:744:4-771:5) — shop has no account mapping → event ignored
- Added `ORDER_COMMERCIAL_INVALID_SHOP` mock constant to [MiraklMockedHttpClient](cci:2://file:///home/zfodor/projects/stripe/stripe-mirakl-connector-official/tests/MiraklMockedHttpClient.php:11:0-1165:1) to support the unknown-shop test scenario

### Minor Cleanup
- Fixed log message cast: `(bool) $event['type']` → `(string) $event['type']` (line 199)